### PR TITLE
Add Windows CLI scaffolding for model downloads

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -33,5 +33,6 @@ BEAR AI (Bridge for Expertise, Audit and Research) aims to deliver a privacy-fir
 2. Prototype document chat and PII scrubbing modules.
 3. Establish CI/CD with GitHub Actions.
 4. Package initial Windows build.
+5. Ship a basic Windows Terminal command-line tool to download GGUF models.
 
 This plan will evolve as the project progresses and new requirements emerge.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,26 @@ BEAR AI (Bridge for Expertise, Audit and Research) is designed for legal profess
 
 ---
 
+## Quick Start: Downloading Models on Windows
+
+The repository includes a small command-line tool for fetching GGUF or other
+model files from the [Hugging Face Hub](https://huggingface.co). This scaffolding
+is intended for use inside **Windows Terminal** or PowerShell and will grow into
+the full BEAR AI desktop experience.
+
+```powershell
+# Install the package in editable mode
+pip install -e .
+
+# Example: download a model file into .\models
+python -m bear_ai TheBloke/Mistral-7B-Instruct-v0.2-GGUF model.q4_0.gguf
+```
+
+The command accepts an optional `--dest` argument to choose a different download
+directory.
+
+---
+
 ## Current Solutions—Their Benefits, Drawbacks, and Common Complaints
 
 ### 1. **LM Studio**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bear-ai"
+version = "0.1.0"
+description = "BEAR AI command line utilities"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "huggingface_hub>=0.20",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+huggingface_hub>=0.20

--- a/src/bear_ai/__init__.py
+++ b/src/bear_ai/__init__.py
@@ -1,0 +1,5 @@
+"""BEAR AI module initialization."""
+
+from .model_downloader import download_model
+
+__all__ = ["download_model"]

--- a/src/bear_ai/__main__.py
+++ b/src/bear_ai/__main__.py
@@ -1,0 +1,28 @@
+"""Command line interface for BEAR AI model downloads."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .model_downloader import download_model
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download LLM models for BEAR AI")
+    parser.add_argument("model", help="Hugging Face model repository ID")
+    parser.add_argument("filename", help="File name within the model repository")
+    parser.add_argument(
+        "--dest",
+        type=Path,
+        default=Path("models"),
+        help="Destination directory for the download (default: ./models)",
+    )
+    args = parser.parse_args()
+
+    path = download_model(args.model, args.filename, destination=args.dest)
+    print(f"Model downloaded to {path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - entrypoint
+    main()

--- a/src/bear_ai/model_downloader.py
+++ b/src/bear_ai/model_downloader.py
@@ -1,0 +1,42 @@
+"""Utilities for downloading LLM models.
+
+This module contains a thin wrapper around `huggingface_hub` for fetching
+GGUF and other model files. It is intentionally light-weight so it can run
+on Windows without additional dependencies.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+try:
+    from huggingface_hub import hf_hub_download
+except ImportError:  # pragma: no cover - library may not be installed at test time
+    hf_hub_download = None  # type: ignore
+
+
+def download_model(model_id: str, filename: str, destination: Optional[Path] = None) -> Path:
+    """Download a model file from the Hugging Face Hub.
+
+    Parameters
+    ----------
+    model_id:
+        Repository ID on the Hugging Face Hub.
+    filename:
+        Name of the file inside the repository to download (e.g. ``model.gguf``).
+    destination:
+        Optional directory where the file will be stored. Defaults to the current
+        working directory.
+
+    Returns
+    -------
+    Path
+        Local path to the downloaded file.
+    """
+    if hf_hub_download is None:
+        raise ImportError("huggingface_hub is required to download models")
+
+    dest = Path(destination) if destination else Path.cwd()
+    dest.mkdir(parents=True, exist_ok=True)
+
+    return Path(hf_hub_download(model_id=model_id, filename=filename, cache_dir=dest))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure src directory is on the Python path for tests
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_model_downloader.py
+++ b/tests/test_model_downloader.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from bear_ai.model_downloader import download_model
+
+
+@patch("bear_ai.model_downloader.hf_hub_download")
+def test_download_model_uses_huggingface(mock_download, tmp_path: Path):
+    mock_download.return_value = tmp_path / "model.gguf"
+
+    result = download_model("owner/repo", "model.gguf", destination=tmp_path)
+
+    mock_download.assert_called_once_with(
+        model_id="owner/repo", filename="model.gguf", cache_dir=tmp_path
+    )
+    assert result == tmp_path / "model.gguf"
+
+
+def test_missing_dependency(monkeypatch):
+    monkeypatch.setattr("bear_ai.model_downloader.hf_hub_download", None)
+    with pytest.raises(ImportError):
+        download_model("owner/repo", "model.gguf")


### PR DESCRIPTION
## Summary
- add development plan item for Windows Terminal model downloader
- scaffold `bear_ai` package with Hugging Face-based model downloader and CLI
- document Windows quick start and add tests

## Testing
- `python -m pytest -q`
- `PYTHONPATH=src python -m bear_ai --help`
- `python -m pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*

------
https://chatgpt.com/codex/tasks/task_b_68b1b3a76490832f9e6e5f49276d2f66