### PR TITLE
feat: list available files in model repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ python -m bear_ai TheBloke/Mistral-7B-Instruct-v0.2-GGUF model.q4_0.gguf
 ```
 
 The command accepts an optional `--dest` argument to choose a different download
-directory.
+directory. To inspect available files before downloading, use:
+
+```powershell
+python -m bear_ai TheBloke/Mistral-7B-Instruct-v0.2-GGUF --list
+```
 
 ---
 

--- a/src/bear_ai/__init__.py
+++ b/src/bear_ai/__init__.py
@@ -1,5 +1,5 @@
 """BEAR AI module initialization."""
 
-from .model_downloader import download_model
+from .model_downloader import download_model, list_model_files
 
-__all__ = ["download_model"]
+__all__ = ["download_model", "list_model_files"]

--- a/src/bear_ai/__main__.py
+++ b/src/bear_ai/__main__.py
@@ -5,20 +5,38 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from .model_downloader import download_model
+from .model_downloader import download_model, list_model_files
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Download LLM models for BEAR AI")
     parser.add_argument("model", help="Hugging Face model repository ID")
-    parser.add_argument("filename", help="File name within the model repository")
+    parser.add_argument(
+        "filename",
+        nargs="?",
+        help="File name within the model repository",
+    )
     parser.add_argument(
         "--dest",
         type=Path,
         default=Path("models"),
         help="Destination directory for the download (default: ./models)",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List available files for the given model and exit",
+    )
+    args = parser.parse_args(argv)
+
+    if args.list:
+        files = list_model_files(args.model)
+        for name in files:
+            print(name)
+        return
+
+    if not args.filename:
+        parser.error("filename is required unless --list is specified")
 
     path = download_model(args.model, args.filename, destination=args.dest)
     print(f"Model downloaded to {path}")

--- a/src/bear_ai/model_downloader.py
+++ b/src/bear_ai/model_downloader.py
@@ -10,9 +10,10 @@ from pathlib import Path
 from typing import Optional
 
 try:
-    from huggingface_hub import hf_hub_download
+    from huggingface_hub import hf_hub_download, list_repo_files
 except ImportError:  # pragma: no cover - library may not be installed at test time
     hf_hub_download = None  # type: ignore
+    list_repo_files = None  # type: ignore
 
 
 def download_model(model_id: str, filename: str, destination: Optional[Path] = None) -> Path:
@@ -40,3 +41,22 @@ def download_model(model_id: str, filename: str, destination: Optional[Path] = N
     dest.mkdir(parents=True, exist_ok=True)
 
     return Path(hf_hub_download(model_id=model_id, filename=filename, cache_dir=dest))
+
+
+def list_model_files(model_id: str) -> list[str]:
+    """Return the list of files available in a Hugging Face repository.
+
+    Parameters
+    ----------
+    model_id:
+        Repository ID on the Hugging Face Hub.
+
+    Returns
+    -------
+    list[str]
+        Names of files contained in the repository.
+    """
+    if list_repo_files is None:
+        raise ImportError("huggingface_hub is required to list model files")
+
+    return list_repo_files(model_id=model_id)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from bear_ai.__main__ import main
+
+
+def test_cli_lists_files(capsys):
+    with patch("bear_ai.__main__.list_model_files") as mock_list:
+        mock_list.return_value = ["a.gguf", "b.gguf"]
+        main(["owner/repo", "--list"])
+        mock_list.assert_called_once_with("owner/repo")
+    captured = capsys.readouterr()
+    assert "a.gguf" in captured.out
+    assert "b.gguf" in captured.out
+
+
+@patch("bear_ai.__main__.download_model")
+def test_cli_downloads_model(mock_download, tmp_path: Path, capsys):
+    mock_download.return_value = tmp_path / "model.gguf"
+    main(["owner/repo", "model.gguf", "--dest", str(tmp_path)])
+    mock_download.assert_called_once_with("owner/repo", "model.gguf", destination=tmp_path)
+    captured = capsys.readouterr()
+    assert f"Model downloaded to {tmp_path / 'model.gguf'}" in captured.out

--- a/tests/test_model_downloader.py
+++ b/tests/test_model_downloader.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from bear_ai.model_downloader import download_model
+from bear_ai.model_downloader import download_model, list_model_files
 
 
 @patch("bear_ai.model_downloader.hf_hub_download")
@@ -22,3 +22,19 @@ def test_missing_dependency(monkeypatch):
     monkeypatch.setattr("bear_ai.model_downloader.hf_hub_download", None)
     with pytest.raises(ImportError):
         download_model("owner/repo", "model.gguf")
+
+
+@patch("bear_ai.model_downloader.list_repo_files")
+def test_list_model_files_uses_huggingface(mock_list):
+    mock_list.return_value = ["a.gguf", "b.gguf"]
+
+    result = list_model_files("owner/repo")
+
+    mock_list.assert_called_once_with(model_id="owner/repo")
+    assert result == ["a.gguf", "b.gguf"]
+
+
+def test_list_model_files_missing_dependency(monkeypatch):
+    monkeypatch.setattr("bear_ai.model_downloader.list_repo_files", None)
+    with pytest.raises(ImportError):
+        list_model_files("owner/repo")


### PR DESCRIPTION
## Summary
- add `list_model_files` helper to query Hugging Face repo contents
- extend CLI with `--list` flag and optional filename
- document model listing in README and test CLI behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b1b623c048832f9b52364e74165424