### PR TITLE
Install llama runtime upfront and improve logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ is intended for use inside **Windows Terminal** or PowerShell and will grow into
 the full BEAR AI desktop experience.
 
 ```powershell
-# Install the package in editable mode
-pip install -e .
+# Install the package in editable mode (including inference runtime)
+pip install -e .[inference]
 
 # Example: download a model file into .\models
 python -m bear_ai TheBloke/Mistral-7B-Instruct-v0.2-GGUF model.q4_0.gguf
@@ -391,7 +391,7 @@ type input.txt | bear-scrub > output.txt
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to get involved.
 
 ## Quick Start
-pip install -e .
+pip install -e .[inference]
 python -m bear_ai TheBloke/Mistral-7B-Instruct-v0.2-GGUF --list
 python -m bear_ai TheBloke/Mistral-7B-Instruct-v0.2-GGUF model.q4_0.gguf
 python -m bear_ai.gui
@@ -408,7 +408,7 @@ scripts\install.ps1      # or: double-click scripts\install.bat
 ```
 
 What it does:
-- Creates `.venv`, upgrades pip, installs `bear_ai`
+- Creates `.venv`, upgrades pip, installs `bear_ai` with inference runtime
 - Installs hardware extras automatically if `nvidia-smi` is detected (or pass `-HW`)
 - Optional flags: `-Dev` for dev tools, `-BuildExe` to generate `dist/bear_ai.exe`
 
@@ -458,7 +458,7 @@ scripts\install.ps1      # or: double-click scripts\install.bat
 ```
 
 What it does:
-- Creates `.venv`, upgrades pip, installs `bear_ai`
+- Creates `.venv`, upgrades pip, installs `bear_ai` with inference runtime
 - Installs hardware extras automatically if `nvidia-smi` is detected (or pass `-HW`)
 - Optional flags: `-Dev` for dev tools, `-BuildExe` to generate `dist/bear_ai.exe`
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -45,8 +45,8 @@ if (-not (Test-Path $venvPy)) { throw "Failed to create .venv (missing $venvPy)"
 Write-Host "Upgrading pip..."
 & $venvPy -m pip install -U pip
 
-Write-Host "Installing BEAR AI (editable)..."
-& $venvPy -m pip install -e .
+Write-Host "Installing BEAR AI (editable, with inference runtime)..."
+& $venvPy -m pip install -e .[inference]
 
 # Optional extras
 $hasNvidiaSmi = (Get-Command nvidia-smi -ErrorAction SilentlyContinue) -ne $null

--- a/src/bear_ai/logging_utils.py
+++ b/src/bear_ai/logging_utils.py
@@ -2,7 +2,7 @@ import json
 import logging
 import pathlib
 from logging.handlers import RotatingFileHandler
-from datetime import datetime
+from datetime import datetime, timezone
 
 LOG_PATH = pathlib.Path("bear_ai.log")
 
@@ -19,5 +19,6 @@ def _ensure_logger() -> logging.Logger:
 
 def audit_log(event: str, details: dict):
     logger = _ensure_logger()
-    payload = {"event": event, "ts": datetime.utcnow().isoformat() + "Z", **details}
+    ts = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    payload = {"event": event, "ts": ts, **details}
     logger.info("AUDIT %s", json.dumps(payload, ensure_ascii=False))


### PR DESCRIPTION
## Summary
- ensure GUI installs llama-cpp runtime at launch and before chats
- install inference runtime during Windows installation scripts and document default usage
- use timezone-aware timestamps in audit logs

## Testing
- `pytest`
- `pre-commit run --files README.md scripts/install.ps1 src/bear_ai/logging_utils.py src/bear_ai/gui.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b6939c7bac832fbecf62324033c789