### PR TITLE
Add Hugging Face context window detection

### DIFF
--- a/src/bear_ai/__main__.py
+++ b/src/bear_ai/__main__.py
@@ -1,6 +1,12 @@
 import argparse
 import sys
-from .download import list_files, resolve_selection, download_many, list_files_with_sizes
+from .download import (
+    list_files,
+    resolve_selection,
+    download_many,
+    list_files_with_sizes,
+    get_context_length,
+)
 from .logging_utils import audit_log
 from .hw import hw_summary
 from .model_compat import combined_fit
@@ -16,6 +22,9 @@ def do_assess(model_id: str):
     if not files:
         print("No files found to assess")
         return
+    ctx = get_context_length(model_id)
+    if ctx:
+        print(f"Context window: {ctx} tokens")
     print(
         f"Hardware: RAM {hw['free_ram_gb']}/{hw['ram_gb']} GB free/total, VRAM {hw['gpu_vram_gb'] or 'None'} GB"
     )


### PR DESCRIPTION
## Summary
- derive model context window from Hugging Face `config.json`
- surface context window in `--assess` command output
- test context window extraction helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b6e9a17134832f8e92b5e4d56fb4c6