### PR TITLE
Replace MIT license with proprietary terms

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,11 @@
-MIT License
+Proprietary License
 
-Copyright (c) 2024 BEAR AI
+Copyright (c) 2024 BEAR AI. All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This software and associated documentation files (the "Software") are the proprietary property of BEAR AI and are protected by copyright law.  
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Unless you have received prior written authorization from BEAR AI, you may not copy, reproduce, modify, publish, distribute, sublicense, sell, or otherwise use the Software, in whole or in part.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Any unauthorized use of the Software is strictly prohibited and may result in civil and/or criminal penalties.  
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## Summary
- Rewrite license as proprietary and copyright-protected, disallowing use without explicit permission

## Testing
- `pre-commit run --files LICENSE` *(fails: pre-commit not installed)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement due to proxy restrictions)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'bear_ai.benchmarking.evaluators'; ModuleNotFoundError: No module named 'customtkinter'; ModuleNotFoundError: No module named 'bear_ai.rag.knowledge_base')*

------
https://chatgpt.com/codex/tasks/task_b_68baa9b88190832fb21d48f72dcd6d78