### PR TITLE
Document proprietary licensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Privacy-First, Local-Only AI Assistant for Legal Professionals and Privacy Advocates
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: Proprietary](https://img.shields.io/badge/license-proprietary-red.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![Platform Support](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey.svg)](https://github.com/KingOfTheAce2/BEAR_AI)
 
@@ -280,7 +280,7 @@ BEAR AI is designed with security and privacy as core principles:
 
 ## 📜 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under a proprietary license; see the [LICENSE](LICENSE) file for details.
 
 ## 🙏 Acknowledgments
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -20,7 +20,7 @@ Unlike existing solutions that suffer from vendor lock-in, security vulnerabilit
 - **Model Flexibility**: Support for any GGUF model without restrictions
 - **Professional-Grade Security**: Built-in PII scrubbing with audit trails
 - **User Experience**: Simple installation with powerful advanced features
-- **Open Architecture**: MIT licensed, fully extensible, no vendor lock-in
+- **Modular Architecture**: Proprietary license, extensible with permission, distribution restricted
 
 ### Addressing Competitor Shortcomings
 

--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,7 @@ setup(
         "Intended Audience :: End Users/Desktop",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: Software Development :: Libraries :: Python Modules",
-        "License :: OSI Approved :: MIT License",
+        "License :: Other/Proprietary License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -209,7 +209,7 @@ setup(
     zip_safe=False,
     
     # Additional metadata
-    license="MIT",
+    license="Proprietary",
     platforms=["any"],
 )
 

--- a/src/bear_ai.egg-info/PKG-INFO
+++ b/src/bear_ai.egg-info/PKG-INFO
@@ -88,7 +88,7 @@ Dynamic: license-file
 
 > Privacy-First, Local-Only AI Assistant for Legal Professionals and Privacy Advocates
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: Proprietary](https://img.shields.io/badge/license-proprietary-red.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![Platform Support](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey.svg)](https://github.com/KingOfTheAce2/BEAR_AI)
 
@@ -364,7 +364,7 @@ BEAR AI is designed with security and privacy as core principles:
 
 ## 📜 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under a proprietary license; see the [LICENSE](LICENSE) file for details.
 
 ## 🙏 Acknowledgments
 

--- a/src/bear_ai/setup.py
+++ b/src/bear_ai/setup.py
@@ -231,7 +231,7 @@ class SetupManager:
         print()
         
         # Basic license agreement
-        print("By continuing, you agree to the MIT License terms.")
+        print("By continuing, you agree to the BEAR AI proprietary license terms.")
         response = input("Continue? (y/N): ").strip().lower()
         if response != 'y':
             print("Setup cancelled.")
@@ -286,21 +286,17 @@ class SetupManager:
         """Show license agreement"""
         
         license_text = """
-BEAR AI is released under the MIT License.
+BEAR AI is distributed under a proprietary license.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Copyright (c) 2024 BEAR AI. All rights reserved.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+This software and associated documentation files (the "Software") are the proprietary property of BEAR AI and are protected by copyright law.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+Unless you have received prior written authorization from BEAR AI, you may not copy, reproduce, modify, publish, distribute, sublicense, sell, or otherwise use the Software, in whole or in part.
+
+Any unauthorized use of the Software is strictly prohibited and may result in civil and/or criminal penalties.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         """
         
         console.print(Panel(


### PR DESCRIPTION
## Summary
- Replace MIT references with proprietary license in README and docs
- Update setup metadata and installer scripts to reference proprietary license terms
- Refresh package metadata with new license badge and text

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bear_ai.benchmarking.evaluators'; ModuleNotFoundError: No module named 'customtkinter'; ModuleNotFoundError: No module named 'bear_ai.rag.knowledge_base')*

------
https://chatgpt.com/codex/tasks/task_b_68baae514384832fa645b45254fb59ca