### PR TITLE
Normalize validation error handling and type async handler

### DIFF
--- a/src/api/middleware/errorHandler.ts
+++ b/src/api/middleware/errorHandler.ts
@@ -1,5 +1,5 @@
 // Comprehensive error handling middleware
-import { Request, Response, NextFunction } from 'express';
+import { Request, Response, NextFunction, RequestHandler } from 'express';
 import { ApiError } from '@/api/types/api';
 
 /**
@@ -296,8 +296,16 @@ export function notFoundHandler(req: Request, res: Response): void {
 /**
  * Async error wrapper for route handlers
  */
-export function asyncHandler(fn: Function) {
-  return (req: Request, res: Response, next: NextFunction) => {
+export function asyncHandler<
+  P = Request['params'],
+  ResBody = any,
+  ReqBody = any,
+  ReqQuery = Request['query'],
+  Locals extends Record<string, any> = Record<string, any>
+>(
+  fn: (req: Request<P, ResBody, ReqBody, ReqQuery, Locals>, res: Response<ResBody, Locals>, next: NextFunction) => Promise<unknown> | unknown
+): RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals> {
+  return (req, res, next) => {
     Promise.resolve(fn(req, res, next)).catch(next);
   };
 }

--- a/tests/validation/vllm-features-validation.test.ts
+++ b/tests/validation/vllm-features-validation.test.ts
@@ -238,7 +238,7 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
           name: 'Unified Engine Initialization',
           status: 'FAIL',
           duration,
-          error: error.message
+          error: getErrorMessage(error)
         });
         throw error;
       }
@@ -289,7 +289,7 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
           name: 'Single Inference Request',
           status: 'FAIL',
           duration,
-          error: error.message
+          error: getErrorMessage(error)
         });
         throw error;
       }
@@ -343,7 +343,7 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
           name: 'Batch Inference Processing',
           status: 'FAIL',
           duration,
-          error: error.message
+          error: getErrorMessage(error)
         });
         throw error;
       }
@@ -380,7 +380,7 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
           name: 'Performance Optimizations',
           status: 'FAIL',
           duration,
-          error: error.message
+          error: getErrorMessage(error)
         });
         throw error;
       }
@@ -447,7 +447,7 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
           name: 'GPU Service Initialization',
           status: 'FAIL',
           duration,
-          error: error.message
+          error: getErrorMessage(error)
         });
         throw error;
       }
@@ -504,7 +504,7 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
           name: 'Matrix Multiplication Acceleration',
           status: 'FAIL',
           duration,
-          error: error.message
+          error: getErrorMessage(error)
         });
         throw error;
       }
@@ -554,7 +554,7 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
           name: 'Vector Addition Acceleration',
           status: 'FAIL',
           duration,
-          error: error.message
+          error: getErrorMessage(error)
         });
         throw error;
       }
@@ -595,7 +595,7 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
           name: 'Multi-Backend Benchmarking',
           status: 'FAIL',
           duration,
-          error: error.message
+          error: getErrorMessage(error)
         });
         throw error;
       }
@@ -656,7 +656,7 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
           name: 'Queue Manager Initialization',
           status: 'FAIL',
           duration,
-          error: error.message
+          error: getErrorMessage(error)
         });
         throw error;
       }
@@ -709,7 +709,7 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
           name: 'Concurrent Request Processing',
           status: 'FAIL',
           duration,
-          error: error.message
+          error: getErrorMessage(error)
         });
         throw error;
       }
@@ -758,7 +758,7 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
           name: 'Dynamic Scaling',
           status: 'FAIL',
           duration,
-          error: error.message
+          error: getErrorMessage(error)
         });
         throw error;
       }
@@ -824,7 +824,7 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
           name: 'Streaming Service Initialization',
           status: 'FAIL',
           duration,
-          error: error.message
+          error: getErrorMessage(error)
         });
         throw error;
       }
@@ -919,7 +919,7 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
           name: 'Async Processing Capabilities',
           status: 'FAIL',
           duration,
-          error: error.message
+          error: getErrorMessage(error)
         });
         throw error;
       }
@@ -996,7 +996,7 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
           name: 'Memory Usage Monitoring',
           status: 'FAIL',
           duration,
-          error: error.message
+          error: getErrorMessage(error)
         });
         throw error;
       }
@@ -1050,7 +1050,7 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
           name: 'Memory-Constrained Scenarios',
           status: 'FAIL',
           duration,
-          error: error.message
+          error: getErrorMessage(error)
         });
         throw error;
       }
@@ -1130,7 +1130,7 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
           name: 'Zero External Dependencies',
           status: 'FAIL',
           duration,
-          error: error.message
+          error: getErrorMessage(error)
         });
         throw error;
       }
@@ -1172,7 +1172,7 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
           name: 'Localhost-Only Operation',
           status: 'FAIL',
           duration,
-          error: error.message
+          error: getErrorMessage(error)
         });
         throw error;
       }
@@ -1202,6 +1202,21 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
   });
 
   // Helper functions
+  function getErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    if (typeof error === 'object' && error !== null && 'message' in error) {
+      const message = (error as { message?: unknown }).message;
+      if (typeof message === 'string') {
+        return message;
+      }
+    }
+
+    return String(error);
+  }
+
   function createEmptyFeatureValidation(): FeatureValidation {
     return {
       status: 'SKIP',
@@ -1226,7 +1241,7 @@ describe('vLLM-Inspired Features Comprehensive Validation', () => {
       }
     });
     
-    return scores.reduce((sum, score) => sum + score, 0) / scores.length;
+    return scores.reduce<number>((sum, score) => sum + score, 0) / scores.length;
   }
 
   function aggregateTestMetrics(testResults: TestResult[]): Record<string, number> {


### PR DESCRIPTION
## Summary
- add a `getErrorMessage` helper in the vLLM validation suite and use it for all caught errors so the catch variable stays type-safe
- explicitly type the feature-score reducer to keep its accumulator numeric
- give the shared `asyncHandler` proper Express generics so route callbacks infer `Request`/`Response` instead of `any`

## Testing
- npm run typecheck *(fails: repository currently has numerous unrelated TS errors referencing vitest config and missing exports)*

------
https://chatgpt.com/codex/tasks/task_e_68ca800d76bc8329a222c0889507ac12