### PR TITLE
Tighten chat streaming and legal typing checks

### DIFF
--- a/src/services/chatIntegration.ts
+++ b/src/services/chatIntegration.ts
@@ -11,7 +11,7 @@ export class ChatStreamingIntegration {
   ): Promise<StreamingMessage> {
     try {
       // Ensure connection
-      if (!this.streamingService.getConnectionState().status === 'connected') {
+      if (this.streamingService.getConnectionState().status !== 'connected') {
         await this.streamingService.connect();
       }
 
@@ -32,7 +32,8 @@ export class ChatStreamingIntegration {
         }
       };
     } catch (error) {
-      throw new Error(`Streaming failed: ${error.message}`);
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Streaming failed: ${message}`);
     }
   }
 

--- a/src/services/chatSessions.ts
+++ b/src/services/chatSessions.ts
@@ -7,7 +7,7 @@ import { localChatHistoryService, ChatSession, ChatMessage } from './localChatHi
 import { encryptionService } from './encryption';
 
 // Re-export for easier imports
-export { ChatSession, ChatMessage } from './localChatHistory';
+export type { ChatSession, ChatMessage } from './localChatHistory';
 
 export interface SessionState {
   id: string;
@@ -43,8 +43,8 @@ export interface SessionBackup {
 export class ChatSessionService {
   private static instance: ChatSessionService;
   private sessionManager: SessionManager;
-  private autoSaveInterval: NodeJS.Timeout | null = null;
-  private syncInterval: NodeJS.Timeout | null = null;
+  private autoSaveInterval: ReturnType<typeof setInterval> | null = null;
+  private syncInterval: ReturnType<typeof setInterval> | null = null;
   private readonly AUTOSAVE_INTERVAL = 30000; // 30 seconds
   private readonly SYNC_INTERVAL = 60000; // 1 minute
   private readonly MAX_RETRY_COUNT = 3;
@@ -477,7 +477,7 @@ export class ChatSessionService {
   }
 
   private startAutoSave(): void {
-    if (this.autoSaveInterval) {
+    if (this.autoSaveInterval !== null) {
       clearInterval(this.autoSaveInterval);
     }
 
@@ -487,7 +487,7 @@ export class ChatSessionService {
   }
 
   private startOfflineSync(): void {
-    if (this.syncInterval) {
+    if (this.syncInterval !== null) {
       clearInterval(this.syncInterval);
     }
 

--- a/src/services/inference/localInferenceEngine.ts
+++ b/src/services/inference/localInferenceEngine.ts
@@ -399,17 +399,19 @@ export class LocalInferenceEngine extends EventEmitter {
 
   private async waitForQueueProcessing(request: BatchRequest): Promise<InferenceResult> {
     return new Promise((resolve, reject) => {
+      const context = this;
+
       const checkQueue = () => {
-        const queueIndex = this.inferenceQueue.findIndex(r => r.id === request.id);
+        const queueIndex = context.inferenceQueue.findIndex(r => r.id === request.id);
         if (queueIndex === -1) {
           // Request was processed
           return;
         }
 
-        if (this.activeInferences.size < this.config.maxConcurrentInferences) {
+        if (context.activeInferences.size < context.config.maxConcurrentInferences) {
           // Process the request
-          this.inferenceQueue.splice(queueIndex, 1);
-          this.executeInference(request).then(resolve).catch(reject);
+          context.inferenceQueue.splice(queueIndex, 1);
+          context.executeInference(request).then(resolve).catch(reject);
         } else {
           // Check again later
           setTimeout(checkQueue, 100);

--- a/src/services/userSettings.ts
+++ b/src/services/userSettings.ts
@@ -407,10 +407,16 @@ export class UserSettingsService extends EventEmitter {
   }
 
   async updateAccessibilitySettings(
-    userId: string, 
+    userId: string,
     settings: Partial<UserPreferences['accessibility']>
   ): Promise<void> {
-    await this.updateUserPreferences(userId, { accessibility: settings });
+    const current = await this.getUserPreferences(userId);
+    const updatedAccessibility: UserPreferences['accessibility'] = {
+      ...current.accessibility,
+      ...settings
+    };
+
+    await this.updateUserPreferences(userId, { accessibility: updatedAccessibility });
     this.emit('accessibility.updated', { userId, settings });
   }
 
@@ -438,10 +444,16 @@ export class UserSettingsService extends EventEmitter {
    * Notification settings
    */
   async updateNotificationSettings(
-    userId: string, 
+    userId: string,
     settings: Partial<UserPreferences['notifications']>
   ): Promise<void> {
-    await this.updateUserPreferences(userId, { notifications: settings });
+    const current = await this.getUserPreferences(userId);
+    const updatedNotifications: UserPreferences['notifications'] = {
+      ...current.notifications,
+      ...settings
+    };
+
+    await this.updateUserPreferences(userId, { notifications: updatedNotifications });
     this.emit('notifications.updated', { userId, settings });
   }
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -246,11 +246,13 @@ export interface ConfigImportResult {
 }
 
 // Event types for configuration changes
-export type ConfigEventType = 
+export type ConfigEventType =
   | 'config.loaded'
   | 'config.updated'
   | 'config.validated'
   | 'config.error'
+  | 'config.imported'
+  | 'config.reset'
   | 'preferences.updated'
   | 'feature.toggled'
   | 'hot.reload';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,7 +16,16 @@ export interface Message {
   agentId?: string;
   timestamp: Date;
   status: 'sending' | 'sent' | 'delivered' | 'error';
-  type: 'text' | 'document' | 'analysis' | 'citation' | 'code' | 'file' | 'image' | 'system';
+  type:
+    | 'text'
+    | 'document'
+    | 'analysis'
+    | 'citation'
+    | 'code'
+    | 'file'
+    | 'image'
+    | 'system'
+    | 'legal-query';
   metadata?: {
     confidence?: number;
     sources?: string[];

--- a/src/types/legal.ts
+++ b/src/types/legal.ts
@@ -1,18 +1,11 @@
 // Legal-specific type definitions for BEAR AI
-
-import type {
-  LegalComponentProps as BaseLegalComponentProps,
-  LegalDocumentType as BaseLegalDocumentType,
-  LegalCategory as BaseLegalCategory,
-  DocumentStatus as BaseDocumentStatus,
-  RiskLevel as BaseRiskLevel
-} from './legal';
-
-export type LegalComponentProps = BaseLegalComponentProps;
-export type LegalDocumentType = BaseLegalDocumentType;
-export type LegalCategory = BaseLegalCategory;
-export type DocumentStatus = BaseDocumentStatus;
-export type RiskLevel = BaseRiskLevel;
+export type {
+  LegalComponentProps,
+  LegalDocumentType,
+  LegalCategory,
+  DocumentStatus,
+  RiskLevel
+} from './legal/index';
 
 export interface LegalCitation {
   id: string;
@@ -66,6 +59,7 @@ export interface LegalContext {
   matter: string;
   practiceArea: PracticeArea;
   jurisdiction: Jurisdiction;
+  confidentialityLevel?: 'public' | 'attorney-client' | 'work-product' | 'confidential';
   relevantDocuments: string[];
   keyIssues: string[];
   timeline: LegalEvent[];


### PR DESCRIPTION
## Summary
- guard the chat streaming integration against disconnected transports and surface safer error messages
- normalize chat session timers for browser environments, adjust the legal chat flow to work with the available streaming API, and widen message typing for legal queries
- merge partial accessibility and notification preferences with stored settings and re-export legal types without circular self-references

## Testing
- npm run typecheck *(fails: hundreds of pre-existing type errors remain in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1b696b4883298d7eef058ffc5591