### PR TITLE
Add UI primitives and legal research service for local flows

### DIFF
--- a/src/components/legal/LegalResearchInterface.tsx
+++ b/src/components/legal/LegalResearchInterface.tsx
@@ -16,7 +16,7 @@ import {
   Eye,
   Copy,
   Share2,
-  History,
+  Clock,
   Lightbulb,
   AlertCircle,
   CheckCircle
@@ -387,7 +387,7 @@ export const LegalResearchInterface: React.FC<LegalResearchInterfaceProps> = ({
       {recentSearches.length > 0 && !searchResults.length && (
         <div className="bg-white border border-gray-200 rounded-lg p-6">
           <h3 className="text-lg font-medium text-gray-900 mb-4 flex items-center">
-            <History className="w-5 h-5 mr-2" />
+            <Clock className="w-5 h-5 mr-2" />
             Recent Searches
           </h3>
           <div className="flex flex-wrap gap-2">

--- a/src/components/local/LocalSettingsPanel.tsx
+++ b/src/components/local/LocalSettingsPanel.tsx
@@ -21,7 +21,7 @@ import {
   FileText,
   Bell,
   BellOff,
-  Palette,
+  Paintbrush,
   Sun,
   Moon,
   Volume2,
@@ -760,7 +760,7 @@ export const LocalSettingsPanel: React.FC<LocalSettingsPanelProps> = ({
           <TabsContent value="interface" className="space-y-6">
             <div>
               <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-                <Palette className="w-5 h-5" />
+                <Paintbrush className="w-5 h-5" />
                 Appearance
               </h3>
 

--- a/src/components/local/index.ts
+++ b/src/components/local/index.ts
@@ -14,15 +14,25 @@
  */
 
 // Core Components
-export { default as LocalModelSelector } from './LocalModelSelector';
-export { default as LocalFileBrowser } from './LocalFileBrowser';
-export { default as LocalChatInterface } from './LocalChatInterface';
-export { default as LocalSettingsPanel } from './LocalSettingsPanel';
+import LocalModelSelector from './LocalModelSelector';
+import LocalFileBrowser from './LocalFileBrowser';
+import LocalChatInterface from './LocalChatInterface';
+import LocalSettingsPanel from './LocalSettingsPanel';
 
 // System Components
-export { default as OfflineErrorHandler } from './OfflineErrorHandler';
-export { default as LocalPerformanceDashboard } from './LocalPerformanceDashboard';
-export { default as PrivacyIndicators } from './PrivacyIndicators';
+import OfflineErrorHandler from './OfflineErrorHandler';
+import LocalPerformanceDashboard from './LocalPerformanceDashboard';
+import PrivacyIndicators from './PrivacyIndicators';
+
+export {
+  LocalModelSelector,
+  LocalFileBrowser,
+  LocalChatInterface,
+  LocalSettingsPanel,
+  OfflineErrorHandler,
+  LocalPerformanceDashboard,
+  PrivacyIndicators,
+};
 
 // Type Definitions
 export type {

--- a/src/components/model/ModelManager.tsx
+++ b/src/components/model/ModelManager.tsx
@@ -17,7 +17,7 @@ import {
   ChartBarIcon
 } from '@heroicons/react/24/outline';
 import { useModelManager } from '../../hooks/useModelManager';
-import { ModelStatus, ModelType } from '../../types/modelTypes';
+import { ModelStatus, ModelStatusType, ModelType } from '../../types/modelTypes';
 import ModelConfigManager from '../../services/modelConfigManager';
 
 interface ModelManagerProps {
@@ -91,7 +91,7 @@ export const ModelManager: React.FC<ModelManagerProps> = ({
     }
   };
 
-  const getStatusIcon = (status: ModelStatus) => {
+  const getStatusIcon = (status: ModelStatusType) => {
     switch (status) {
       case ModelStatus.LOADED:
         return <CheckCircleIcon className="w-5 h-5 text-green-500" />;

--- a/src/components/model/huggingface/FineTuningInterface.tsx
+++ b/src/components/model/huggingface/FineTuningInterface.tsx
@@ -13,7 +13,7 @@ import {
   Cog6ToothIcon,
   ExclamationCircleIcon,
   CheckCircleIcon,
-  ArrowUpTrayIcon,
+  ArrowUpOnSquareIcon,
   CloudArrowDownIcon,
   BeakerIcon,
   AcademicCapIcon
@@ -62,17 +62,18 @@ const DatasetUpload: React.FC<DatasetUploadProps> = ({
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
   const [validationResult, setValidationResult] = useState<{ valid: boolean; issues: string[] } | null>(null);
 
-  const handleDrag = (e: React.DragEvent) => {
+  const handleDrag = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
-    if (e.type === 'dragenter' || e.type === 'dragover') {
+    const eventType = e.type;
+    if (eventType === 'dragenter' || eventType === 'dragover') {
       setDragActive(true);
-    } else if (e.type === 'dragleave') {
+    } else if (eventType === 'dragleave') {
       setDragActive(false);
     }
   };
 
-  const handleDrop = (e: React.DragEvent) => {
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
     setDragActive(false);
@@ -140,7 +141,7 @@ const DatasetUpload: React.FC<DatasetUploadProps> = ({
           onDragOver={handleDrag}
           onDrop={handleDrop}
         >
-          <ArrowUpTrayIcon className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+          <ArrowUpOnSquareIcon className="w-12 h-12 text-gray-400 mx-auto mb-4" />
           <p className="text-lg font-medium text-gray-900 mb-2">
             Drop your dataset here
           </p>

--- a/src/components/types/localTypes.ts
+++ b/src/components/types/localTypes.ts
@@ -1,0 +1,270 @@
+// Shared type definitions for local-first components
+// These interfaces mirror the structures used inside the UI components
+// so that other modules can import consistent typings without relying
+// on component internals.
+
+export interface LocalModel {
+  id: string;
+  name: string;
+  displayName: string;
+  size: string;
+  sizeBytes: number;
+  format: 'GGUF' | 'ONNX' | 'PyTorch' | 'Safetensors';
+  quantization: 'Q4_0' | 'Q4_1' | 'Q5_0' | 'Q5_1' | 'Q8_0' | 'F16' | 'F32';
+  parameters: string;
+  isDownloaded: boolean;
+  isActive: boolean;
+  localPath?: string;
+  downloadProgress?: number;
+  lastUsed?: Date;
+  memoryRequirement: number;
+  cpuOptimized: boolean;
+  gpuCompatible: boolean;
+  description: string;
+  license: string;
+  capabilities: string[];
+  performance: {
+    tokensPerSecond: number;
+    memoryUsage: number;
+    averageLatency: number;
+  };
+}
+
+export interface FileSystemItem {
+  id: string;
+  name: string;
+  path: string;
+  type: 'file' | 'directory';
+  size?: number;
+  lastModified: Date;
+  isHidden: boolean;
+  permissions: {
+    readable: boolean;
+    writable: boolean;
+    executable: boolean;
+  };
+  mimeType?: string;
+  isSymlink?: boolean;
+  isEncrypted?: boolean;
+  isIndexed?: boolean;
+  preview?: {
+    text?: string;
+    thumbnail?: string;
+  };
+  metadata?: {
+    description?: string;
+    tags?: string[];
+    lastAccessed?: Date;
+    security?: 'safe' | 'warning' | 'restricted';
+  };
+}
+
+export interface ChatMessage {
+  id: string;
+  type: 'user' | 'assistant' | 'system';
+  content: string;
+  timestamp: Date;
+  metadata?: {
+    modelUsed?: string;
+    tokensUsed?: number;
+    responseTime?: number;
+    temperature?: number;
+    attachments?: string[];
+    storedLocally: boolean;
+    encrypted: boolean;
+  };
+  status: 'sending' | 'sent' | 'generating' | 'completed' | 'error';
+  error?: string;
+  isStreaming?: boolean;
+  parentId?: string;
+}
+
+export interface ChatSession {
+  id: string;
+  name: string;
+  createdAt: Date;
+  lastModified: Date;
+  messageCount: number;
+  modelUsed: string;
+  isEncrypted: boolean;
+  localPath: string;
+  size: number;
+  metadata: {
+    tags: string[];
+    description?: string;
+    archived: boolean;
+  };
+}
+
+export interface LocalSettings {
+  privacy: {
+    encryptionEnabled: boolean;
+    encryptionKey: string;
+    autoDeleteAfterDays: number;
+    requireAuthOnStart: boolean;
+    allowTelemetry: boolean;
+    anonymizeData: boolean;
+  };
+  storage: {
+    dataDirectory: string;
+    maxCacheSize: number;
+    autoCleanup: boolean;
+    compressionEnabled: boolean;
+    backupEnabled: boolean;
+    backupLocation: string;
+  };
+  inference: {
+    defaultModel: string;
+    maxMemoryUsage: number;
+    threadCount: number;
+    useGPU: boolean;
+    quantizationLevel: 'Q4_0' | 'Q4_1' | 'Q5_0' | 'Q5_1' | 'Q8_0' | 'F16';
+    contextWindow: number;
+    temperature: number;
+  };
+  interface: {
+    theme: 'light' | 'dark' | 'system';
+    fontSize: number;
+    autoSave: boolean;
+    showLineNumbers: boolean;
+    enableSounds: boolean;
+    notificationsEnabled: boolean;
+    startMinimized: boolean;
+    checkUpdates: boolean;
+  };
+  network: {
+    offlineMode: boolean;
+    blockExternalRequests: boolean;
+    allowModelDownloads: boolean;
+    proxyEnabled: boolean;
+    proxyUrl: string;
+  };
+}
+
+export interface ErrorContext {
+  component: string;
+  operation: string;
+  timestamp: Date;
+  userId?: string;
+  sessionId?: string;
+  modelId?: string;
+  filePath?: string;
+  systemInfo?: {
+    memory: number;
+    cpu: number;
+    disk: number;
+  };
+}
+
+export interface OfflineError {
+  id: string;
+  type: 'network' | 'storage' | 'memory' | 'model' | 'file' | 'permission' | 'system' | 'data';
+  severity: 'low' | 'medium' | 'high' | 'critical';
+  title: string;
+  message: string;
+  details?: string;
+  context: ErrorContext;
+  suggestions: string[];
+  isResolved: boolean;
+  canRetry: boolean;
+  requiresRestart: boolean;
+  autoResolved: boolean;
+  retryCount: number;
+  maxRetries: number;
+  localDataLoss: boolean;
+  privacyImpact: boolean;
+}
+
+export interface PerformanceMetrics {
+  timestamp: Date;
+  cpu: {
+    usage: number;
+    cores: number;
+    frequency: number;
+    temperature?: number;
+  };
+  memory: {
+    used: number;
+    total: number;
+    cached: number;
+    swapUsed: number;
+    swapTotal: number;
+  };
+  disk: {
+    read: number;
+    write: number;
+    usage: number;
+    available: number;
+    total: number;
+  };
+  network: {
+    bytesReceived: number;
+    bytesSent: number;
+    packetsReceived: number;
+    packetsSent: number;
+    isOffline: boolean;
+  };
+  model: {
+    tokensPerSecond: number;
+    averageLatency: number;
+    memoryUsage: number;
+    contextWindowUsage: number;
+    isLoaded: boolean;
+    modelName?: string;
+  };
+  application: {
+    uptime: number;
+    threadsCount: number;
+    fileHandles: number;
+    cacheHitRate: number;
+    errorCount: number;
+    warningCount: number;
+  };
+}
+
+export interface PrivacyStatus {
+  networkIsolation: {
+    status: 'secure' | 'warning' | 'compromised';
+    blockedRequests: number;
+    lastExternalAttempt?: Date;
+    dnsLeaks: boolean;
+    vpnActive: boolean;
+  };
+  dataEncryption: {
+    status: 'encrypted' | 'partial' | 'unencrypted';
+    algorithm: string;
+    keyStrength: number;
+    encryptedFiles: number;
+    totalFiles: number;
+    encryptionProgress?: number;
+  };
+  localStorage: {
+    status: 'local' | 'cloud' | 'mixed';
+    totalSize: number;
+    backupLocation: 'local' | 'none';
+    compressionEnabled: boolean;
+    autoDelete: boolean;
+    retentionDays: number;
+  };
+  dataMinimization: {
+    status: 'minimal' | 'standard' | 'excessive';
+    piiDetected: boolean;
+    anonymized: boolean;
+    trackedMetrics: string[];
+    optOutStatus: boolean;
+  };
+  accessControl: {
+    status: 'protected' | 'basic' | 'open';
+    authenticationEnabled: boolean;
+    sessionTimeout: number;
+    failedAttempts: number;
+    lastAccess: Date;
+  };
+  auditTrail: {
+    enabled: boolean;
+    logLevel: 'minimal' | 'standard' | 'detailed';
+    eventsLogged: number;
+    suspiciousActivity: number;
+    lastAudit: Date;
+  };
+}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      role="alert"
+      className={cn('w-full rounded-lg border border-border bg-background/80 p-4 text-sm shadow-sm', className)}
+      {...props}
+    />
+  )
+);
+Alert.displayName = 'Alert';
+
+export interface AlertTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {}
+
+export const AlertTitle = React.forwardRef<HTMLHeadingElement, AlertTitleProps>(
+  ({ className, ...props }, ref) => (
+    <h5
+      ref={ref}
+      className={cn('mb-1 text-sm font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
+  )
+);
+AlertTitle.displayName = 'AlertTitle';
+
+export interface AlertDescriptionProps extends React.HTMLAttributes<HTMLParagraphElement> {}
+
+export const AlertDescription = React.forwardRef<HTMLParagraphElement, AlertDescriptionProps>(
+  ({ className, ...props }, ref) => (
+    <p
+      ref={ref}
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  )
+);
+AlertDescription.displayName = 'AlertDescription';
+
+export default Alert;

--- a/src/components/ui/badge.ts
+++ b/src/components/ui/badge.ts
@@ -1,0 +1,1 @@
+export * from './Badge';

--- a/src/components/ui/button.ts
+++ b/src/components/ui/button.ts
@@ -1,0 +1,1 @@
+export * from './Button';

--- a/src/components/ui/card.ts
+++ b/src/components/ui/card.ts
@@ -1,0 +1,1 @@
+export * from './Card';

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+export interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ className, ...props }, ref) => (
+    <input
+      ref={ref}
+      type="checkbox"
+      className={cn(
+        'h-4 w-4 rounded border border-input bg-background text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Checkbox.displayName = 'Checkbox';
+
+export default Checkbox;

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,126 @@
+import React, { useCallback, useContext, useMemo, useState } from 'react';
+import { cn } from '../../utils/cn';
+
+interface CollapsibleContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const CollapsibleContext = React.createContext<CollapsibleContextValue | null>(null);
+
+const isReactElement = (child: React.ReactNode): child is React.ReactElement =>
+  typeof child === 'object' && child !== null && 'props' in child;
+
+const cloneWithProps = (child: React.ReactNode, props: Record<string, unknown>) => {
+  const clone = (React as any).cloneElement;
+  if (typeof clone === 'function' && isReactElement(child)) {
+    return clone(child, props);
+  }
+  if (isReactElement(child)) {
+    return child;
+  }
+  return (
+    <span {...props}>
+      {child}
+    </span>
+  );
+};
+
+export interface CollapsibleProps {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export const Collapsible: React.FC<CollapsibleProps> = ({
+  open,
+  defaultOpen = false,
+  onOpenChange,
+  className,
+  children,
+}) => {
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (open === undefined) {
+        setInternalOpen(next);
+      }
+      onOpenChange?.(next);
+    },
+    [open, onOpenChange]
+  );
+
+  const contextValue = useMemo<CollapsibleContextValue>(
+    () => ({ open: open ?? internalOpen, setOpen }),
+    [open, internalOpen, setOpen]
+  );
+
+  return (
+    <CollapsibleContext.Provider value={contextValue}>
+      <div className={className}>{children}</div>
+    </CollapsibleContext.Provider>
+  );
+};
+
+export interface CollapsibleTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+}
+
+export const CollapsibleTrigger = React.forwardRef<HTMLButtonElement, CollapsibleTriggerProps>(
+  ({ className, asChild, children, ...props }, ref) => {
+    const context = useContext(CollapsibleContext);
+    if (!context) {
+      throw new Error('CollapsibleTrigger must be used within Collapsible');
+    }
+
+    const handleClick = (event: any) => {
+      context.setOpen(!context.open);
+      props.onClick?.(event);
+    };
+
+    const sharedProps = {
+      ref,
+      onClick: handleClick,
+      'aria-expanded': context.open,
+      className: cn('flex w-full items-center justify-between text-left', className),
+    };
+
+    if (asChild) {
+      return cloneWithProps(children, sharedProps);
+    }
+
+    return (
+      <button type="button" {...props} {...sharedProps}>
+        {children}
+      </button>
+    );
+  }
+);
+CollapsibleTrigger.displayName = 'CollapsibleTrigger';
+
+export interface CollapsibleContentProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const CollapsibleContent = React.forwardRef<HTMLDivElement, CollapsibleContentProps>(
+  ({ className, children, ...props }, ref) => {
+    const context = useContext(CollapsibleContext);
+    if (!context) {
+      throw new Error('CollapsibleContent must be used within Collapsible');
+    }
+
+    return context.open ? (
+      <div
+        ref={ref}
+        className={cn('mt-2 space-y-2', className)}
+        {...props}
+      >
+        {children}
+      </div>
+    ) : null;
+  }
+);
+CollapsibleContent.displayName = 'CollapsibleContent';
+
+export default Collapsible;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -21,3 +21,35 @@ export type { AvatarProps } from './Avatar';
 
 export { MemoryUsageIndicator } from './MemoryUsageIndicator';
 export type { MemoryUsageIndicatorProps } from './MemoryUsageIndicator';
+
+export { Textarea } from './textarea';
+export type { TextareaProps } from './textarea';
+
+export { Progress } from './progress';
+export type { ProgressProps } from './progress';
+
+export { Separator } from './separator';
+export type { SeparatorProps } from './separator';
+
+export { Checkbox } from './checkbox';
+export type { CheckboxProps } from './checkbox';
+
+export { Tabs, TabsContent, TabsList, TabsTrigger } from './tabs';
+export type { TabsProps } from './tabs';
+
+export { Switch } from './switch';
+export type { SwitchProps } from './switch';
+
+export { Label } from './label';
+export type { LabelProps } from './label';
+
+export { Slider } from './slider';
+export type { SliderProps } from './slider';
+
+export { Alert, AlertDescription, AlertTitle } from './alert';
+export type { AlertProps, AlertDescriptionProps, AlertTitleProps } from './alert';
+
+export { Collapsible, CollapsibleContent, CollapsibleTrigger } from './collapsible';
+export type { CollapsibleProps, CollapsibleContentProps, CollapsibleTriggerProps } from './collapsible';
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip';

--- a/src/components/ui/input.ts
+++ b/src/components/ui/input.ts
@@ -1,0 +1,1 @@
+export * from './Input';

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+export interface LabelProps {
+  className?: string;
+  htmlFor?: string;
+  id?: string;
+  children?: React.ReactNode;
+  [key: string]: unknown;
+}
+
+export const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn('text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70', className)}
+      {...props}
+    />
+  )
+);
+Label.displayName = 'Label';
+
+export default Label;

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+export interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
+  value?: number;
+  max?: number;
+}
+
+export const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
+  ({ className, value = 0, max = 100, children, ...props }, ref) => {
+    const safeMax = max <= 0 ? 100 : max;
+    const clamped = Math.min(Math.max(value, 0), safeMax);
+    const percentage = (clamped / safeMax) * 100;
+
+    return (
+      <div
+        ref={ref}
+        className={cn('relative h-2 w-full overflow-hidden rounded-full bg-muted', className)}
+        role="progressbar"
+        aria-valuenow={value}
+        aria-valuemin={0}
+        aria-valuemax={max}
+        {...props}
+      >
+        <div
+          className="h-full bg-primary transition-all"
+          style={{ width: `${percentage}%` }}
+        />
+        {children}
+      </div>
+    );
+  }
+);
+Progress.displayName = 'Progress';
+
+export default Progress;

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+export interface SeparatorProps extends React.HTMLAttributes<HTMLDivElement> {
+  orientation?: 'horizontal' | 'vertical';
+  decorative?: boolean;
+}
+
+export const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>(
+  (
+    { className, orientation = 'horizontal', decorative = false, role, ...props },
+    ref
+  ) => (
+    <div
+      ref={ref}
+      role={decorative ? 'presentation' : role ?? 'separator'}
+      aria-orientation={orientation}
+      className={cn(
+        'bg-border',
+        orientation === 'vertical' ? 'h-full w-px' : 'h-px w-full',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Separator.displayName = 'Separator';
+
+export default Separator;

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+export interface SliderProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  value?: number;
+  onValueChange?: (value: number) => void;
+}
+
+export const Slider = React.forwardRef<HTMLInputElement, SliderProps>(
+  ({ className, value, defaultValue, min = 0, max = 100, step = 1, onValueChange, onChange, ...props }, ref) => {
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      const numericValue = Number(event.target.value);
+      onValueChange?.(numericValue);
+      onChange?.(event);
+    };
+
+    return (
+      <input
+        ref={ref}
+        type="range"
+        value={value}
+        defaultValue={defaultValue}
+        min={min}
+        max={max}
+        step={step}
+        onChange={handleChange}
+        className={cn(
+          'h-2 w-full cursor-pointer appearance-none rounded-full bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Slider.displayName = 'Slider';
+
+export default Slider;

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,50 @@
+import React, { useCallback } from 'react';
+import { cn } from '../../utils/cn';
+
+export interface SwitchProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  checked?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+}
+
+export const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
+  ({ className, checked = false, onCheckedChange, disabled, ...props }, ref) => {
+    const handleClick = useCallback(
+      (event: React.MouseEvent<HTMLButtonElement>) => {
+        if (disabled) {
+          event.preventDefault();
+          return;
+        }
+        onCheckedChange?.(!checked);
+        props.onClick?.(event);
+      },
+      [checked, disabled, onCheckedChange, props]
+    );
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        disabled={disabled}
+        onClick={handleClick}
+        className={cn(
+          'relative inline-flex h-6 w-11 items-center rounded-full border border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          checked ? 'bg-primary' : 'bg-muted',
+          className
+        )}
+        {...props}
+      >
+        <span
+          className={cn(
+            'inline-block h-5 w-5 transform rounded-full bg-background shadow transition-transform',
+            checked ? 'translate-x-5' : 'translate-x-1'
+          )}
+        />
+      </button>
+    );
+  }
+);
+Switch.displayName = 'Switch';
+
+export default Switch;

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,169 @@
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { cn } from '../../utils/cn';
+
+interface TabsContextValue {
+  value: string;
+  setValue: (value: string) => void;
+}
+
+const TabsContext = React.createContext<TabsContextValue | null>(null);
+
+const isReactElement = (child: React.ReactNode): child is React.ReactElement =>
+  typeof child === 'object' && child !== null && 'props' in child;
+
+const cloneWithProps = (child: React.ReactNode, props: Record<string, unknown>) => {
+  const clone = (React as any).cloneElement;
+  if (typeof clone === 'function' && isReactElement(child)) {
+    return clone(child, props);
+  }
+  if (isReactElement(child)) {
+    return child;
+  }
+  return (
+    <span {...props}>
+      {child}
+    </span>
+  );
+};
+
+export interface TabsProps {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export const Tabs: React.FC<TabsProps> = ({
+  value,
+  defaultValue,
+  onValueChange,
+  className,
+  children,
+}) => {
+  const [internalValue, setInternalValue] = useState(defaultValue ?? '');
+
+  useEffect(() => {
+    if (defaultValue !== undefined) {
+      setInternalValue(defaultValue);
+    }
+  }, [defaultValue]);
+
+  const handleChange = useCallback(
+    (next: string) => {
+      if (value === undefined) {
+        setInternalValue(next);
+      }
+      onValueChange?.(next);
+    },
+    [value, onValueChange]
+  );
+
+  const contextValue = useMemo<TabsContextValue>(
+    () => ({ value: value ?? internalValue, setValue: handleChange }),
+    [value, internalValue, handleChange]
+  );
+
+  return (
+    <TabsContext.Provider value={contextValue}>
+      <div className={className}>{children}</div>
+    </TabsContext.Provider>
+  );
+};
+
+export interface TabsListProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const TabsList = React.forwardRef<HTMLDivElement, TabsListProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('inline-flex items-center justify-center rounded-md bg-muted p-1 text-muted-foreground', className)}
+      role="tablist"
+      {...props}
+    />
+  )
+);
+TabsList.displayName = 'TabsList';
+
+export interface TabsTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  value: string;
+  asChild?: boolean;
+}
+
+export const TabsTrigger = React.forwardRef<HTMLButtonElement, TabsTriggerProps>(
+  ({ className, value, asChild, disabled, children, ...props }, ref) => {
+    const context = useContext(TabsContext);
+    if (!context) {
+      throw new Error('TabsTrigger must be used within Tabs');
+    }
+
+    const isActive = context.value === value;
+
+    const sharedProps = {
+      role: 'tab',
+      'aria-selected': isActive,
+      'aria-controls': `${value}-content`,
+      tabIndex: isActive ? 0 : -1,
+      id: value,
+      className: cn(
+        'inline-flex min-w-[100px] items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+        isActive
+          ? 'bg-background text-foreground shadow'
+          : 'text-muted-foreground hover:text-foreground',
+        className
+      ),
+      onClick: (event: any) => {
+        if (disabled) {
+          event.preventDefault();
+          return;
+        }
+        context.setValue(value);
+        props.onClick?.(event);
+      },
+    };
+
+    if (asChild) {
+      return cloneWithProps(children, sharedProps);
+    }
+
+    return (
+      <button ref={ref} disabled={disabled} {...props} {...sharedProps}>
+        {children}
+      </button>
+    );
+  }
+);
+TabsTrigger.displayName = 'TabsTrigger';
+
+export interface TabsContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  value: string;
+}
+
+export const TabsContent = React.forwardRef<HTMLDivElement, TabsContentProps>(
+  ({ className, value, children, ...props }, ref) => {
+    const context = useContext(TabsContext);
+    if (!context) {
+      throw new Error('TabsContent must be used within Tabs');
+    }
+
+    if (context.value !== value) {
+      return null;
+    }
+
+    return (
+      <div
+        ref={ref}
+        role="tabpanel"
+        id={`${value}-content`}
+        aria-labelledby={value}
+        className={cn('mt-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring', className)}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+TabsContent.displayName = 'TabsContent';
+
+export default Tabs;

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+export interface TextareaProps {
+  className?: string;
+  rows?: number;
+  value?: string;
+  defaultValue?: string | number;
+  onChange?: (event: any) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  name?: string;
+  id?: string;
+  children?: React.ReactNode;
+  [key: string]: unknown;
+}
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, rows = 4, ...props }, ref) => (
+    <textarea
+      ref={ref}
+      rows={rows}
+      className={cn(
+        'flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Textarea.displayName = 'Textarea';
+
+export default Textarea;

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,93 @@
+import React, { useContext, useMemo, useState } from 'react';
+import { cn } from '../../utils/cn';
+
+interface TooltipContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const TooltipContext = React.createContext<TooltipContextValue | null>(null);
+
+export interface TooltipProviderProps {
+  children: React.ReactNode;
+}
+
+export const TooltipProvider: React.FC<TooltipProviderProps> = ({ children }) => <>{children}</>;
+
+export interface TooltipProps {
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}
+
+export const Tooltip: React.FC<TooltipProps> = ({ children, defaultOpen = false }) => {
+  const [open, setOpen] = useState(defaultOpen);
+  const value = useMemo<TooltipContextValue>(() => ({ open, setOpen }), [open]);
+
+  return (
+    <TooltipContext.Provider value={value}>
+      <div className="relative inline-flex">{children}</div>
+    </TooltipContext.Provider>
+  );
+};
+
+export interface TooltipTriggerProps extends React.HTMLAttributes<HTMLElement> {
+  asChild?: boolean;
+  children: React.ReactNode;
+}
+
+export const TooltipTrigger: React.FC<TooltipTriggerProps> = ({ children, asChild = false, ...props }) => {
+  const context = useContext(TooltipContext);
+  if (!context) {
+    throw new Error('TooltipTrigger must be used within Tooltip');
+  }
+
+  const triggerProps = {
+    onMouseEnter: () => context.setOpen(true),
+    onMouseLeave: () => context.setOpen(false),
+    onFocus: () => context.setOpen(true),
+    onBlur: () => context.setOpen(false),
+    ...props,
+  };
+
+  const clone = (React as any).cloneElement;
+  const isElement = typeof children === 'object' && children !== null && 'props' in (children as any);
+
+  if (asChild && typeof clone === 'function' && isElement) {
+    return clone(children, triggerProps);
+  }
+
+  if (typeof clone === 'function' && isElement) {
+    return clone(children, triggerProps);
+  }
+
+  return <span {...triggerProps}>{children}</span>;
+};
+
+export interface TooltipContentProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const TooltipContent = React.forwardRef<HTMLDivElement, TooltipContentProps>(
+  ({ className, style, children, ...props }, ref) => {
+    const context = useContext(TooltipContext);
+    if (!context || !context.open) {
+      return null;
+    }
+
+    return (
+      <div
+        ref={ref}
+        role="tooltip"
+        className={cn(
+          'z-50 mt-2 w-max max-w-xs rounded-md border border-border bg-popover px-3 py-2 text-sm text-popover-foreground shadow-md',
+          className
+        )}
+        style={{ position: 'absolute', ...style }}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+TooltipContent.displayName = 'TooltipContent';
+
+export default Tooltip;

--- a/src/services/legal/LegalResearchService.ts
+++ b/src/services/legal/LegalResearchService.ts
@@ -1,0 +1,159 @@
+import { CaseLaw, Statute } from '../../types/legal';
+
+interface SearchOptions {
+  jurisdictions?: string[];
+}
+
+/**
+ * Lightweight mock implementation of the legal research service.
+ * Provides deterministic data so TypeScript consumers can rely on
+ * predictable structures during development without a backend.
+ */
+class LegalResearchService {
+  private caseLaw: CaseLaw[];
+  private statutes: Statute[];
+
+  constructor() {
+    const now = new Date();
+    this.caseLaw = [
+      {
+        id: 'case_mock_1',
+        citation: '456 F.Supp.3d 789 (S.D.N.Y. 2023)',
+        title: 'Hamilton v. DataShield Corp.',
+        court: 'Southern District of New York',
+        jurisdiction: 'New York',
+        date: new Date(now.getFullYear(), 2, 12),
+        judges: ['Hon. Alicia Romero'],
+        parties: ['Amanda Hamilton', 'DataShield Corporation'],
+        summary:
+          'Landmark decision clarifying employer obligations regarding data retention and employee privacy in remote work environments.',
+        holdings: [
+          'Employers must provide clear notice before monitoring employee devices.',
+          'Failure to maintain audit logs can create adverse inference.',
+        ],
+        procedureHistory: 'Appeal from the New York Privacy Board decision.',
+        facts:
+          'The plaintiff alleged that company-issued monitoring software collected personal information without explicit consent.',
+        reasoning:
+          'Court applied a balancing test weighing legitimate business interests against individual privacy expectations.',
+        outcome: 'Partial summary judgment for the plaintiff.',
+        keyWords: ['privacy', 'employment', 'remote work'],
+        shepardization: 'good_law',
+        relevanceScore: 0.86,
+      },
+      {
+        id: 'case_mock_2',
+        citation: '789 F.3d 123 (9th Cir. 2022)',
+        title: 'In re Pacifica Analytics Breach Litigation',
+        court: 'Ninth Circuit Court of Appeals',
+        jurisdiction: 'US Federal',
+        date: new Date(now.getFullYear() - 1, 6, 3),
+        judges: ['Hon. Lee Patterson', 'Hon. Maria Sanchez', 'Hon. Kelly Jordan'],
+        parties: ['Pacifica Analytics, Inc.', 'Numerous Plaintiffs'],
+        summary:
+          'Class action addressing contractual liability and damages following a large-scale analytics platform breach.',
+        holdings: [
+          'Breach notification clauses are enforceable when explicitly negotiated.',
+          'Limitation-of-liability clauses must be prominently disclosed to be effective.',
+        ],
+        procedureHistory: 'Appeal from the Northern District of California.',
+        facts:
+          'Customers alleged that the company failed to patch a known vulnerability, leading to exposure of confidential datasets.',
+        reasoning:
+          'Court emphasized the importance of commercially reasonable security measures and transparent client communication.',
+        outcome: 'Affirmed in part, reversed in part, and remanded.',
+        keyWords: ['data breach', 'contract', 'liability'],
+        westlawKey: '2022 WL 1234567',
+        relevanceScore: 0.81,
+      },
+    ];
+
+    this.statutes = [
+      {
+        id: 'statute_mock_1',
+        citation: 'Cal. Civ. Code § 1798.100',
+        title: 'California Consumer Privacy Act – Data Rights',
+        jurisdiction: 'California',
+        section: '1798.100',
+        text:
+          'Provides California residents with rights to know, delete, and opt-out of the sale of personal information collected by businesses.',
+        effectiveDate: new Date(2020, 0, 1),
+        amendmentHistory: [
+          {
+            date: new Date(2023, 6, 1),
+            description: 'Updated to include additional disclosure obligations for service providers.',
+            changedText: 'Added explicit requirements for employee data handling.',
+            reason: 'Privacy Rights Expansion Act updates.',
+          },
+        ],
+        relatedStatutes: ['Cal. Civ. Code § 1798.150'],
+        annotations: [
+          {
+            type: 'interpretation',
+            content: 'Courts interpret disclosure obligations liberally in favour of consumers.',
+            source: 'California Attorney General Guidance',
+            date: new Date(2023, 6, 15),
+          },
+        ],
+      },
+      {
+        id: 'statute_mock_2',
+        citation: '15 U.S.C. § 6801',
+        title: 'Gramm-Leach-Bliley Act – Protection of Nonpublic Personal Information',
+        jurisdiction: 'US Federal',
+        section: '6801',
+        text:
+          'Requires financial institutions to protect the security and confidentiality of their customers’ nonpublic personal information.',
+        effectiveDate: new Date(1999, 10, 12),
+        amendmentHistory: [],
+        relatedStatutes: ['15 U.S.C. § 6809'],
+        annotations: [
+          {
+            type: 'regulation',
+            content: 'See FTC Safeguards Rule for implementing regulations.',
+            source: 'Federal Trade Commission',
+            date: new Date(2021, 11, 9),
+          },
+        ],
+      },
+    ];
+  }
+
+  async searchCaseLaw(query: string, options: SearchOptions = {}): Promise<CaseLaw[]> {
+    const keyword = query.trim().toLowerCase();
+    const jurisdictions = options.jurisdictions?.map((j) => j.toLowerCase());
+
+    return this.caseLaw.filter((caseItem) => {
+      const matchesQuery =
+        !keyword ||
+        caseItem.title.toLowerCase().includes(keyword) ||
+        caseItem.summary.toLowerCase().includes(keyword) ||
+        caseItem.keyWords.some((word) => word.toLowerCase().includes(keyword));
+      const matchesJurisdiction =
+        !jurisdictions || jurisdictions.length === 0 || jurisdictions.includes(caseItem.jurisdiction.toLowerCase());
+      return matchesQuery && matchesJurisdiction;
+    });
+  }
+
+  async searchStatutes(query: string, options: SearchOptions = {}): Promise<Statute[]> {
+    const keyword = query.trim().toLowerCase();
+    const jurisdictions = options.jurisdictions?.map((j) => j.toLowerCase());
+
+    return this.statutes.filter((statute) => {
+      const matchesQuery =
+        !keyword ||
+        statute.title.toLowerCase().includes(keyword) ||
+        statute.text.toLowerCase().includes(keyword) ||
+        statute.citation.toLowerCase().includes(keyword);
+      const matchesJurisdiction =
+        !jurisdictions || jurisdictions.length === 0 || jurisdictions.includes(statute.jurisdiction.toLowerCase());
+      return matchesQuery && matchesJurisdiction;
+    });
+  }
+
+  async getCaseById(id: string): Promise<CaseLaw | null> {
+    return this.caseLaw.find((item) => item.id === id) || null;
+  }
+}
+
+export default LegalResearchService;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,7 +25,10 @@ export interface Message {
     | 'file'
     | 'image'
     | 'system'
-    | 'legal-query';
+    | 'legal-query'
+    | 'case-law'
+    | 'statute'
+    | 'contract-review';
   metadata?: {
     confidence?: number;
     sources?: string[];

--- a/src/types/legal.ts
+++ b/src/types/legal.ts
@@ -4,7 +4,10 @@ export type {
   LegalDocumentType,
   LegalCategory,
   DocumentStatus,
-  RiskLevel
+  RiskLevel,
+  CaseLaw,
+  Statute,
+  Citation
 } from './legal/index';
 
 export interface LegalCitation {


### PR DESCRIPTION
## Summary
- replace the unavailable history icon with clock in the legal research interface and wire it to a lightweight mock `LegalResearchService` while exporting the necessary legal research types
- extend message type metadata so legal message bubbles accept case law, statute, and contract review roles
- supply local-first components with the missing UI primitives (tabs, tooltip, slider, textarea, etc.) and shared local type definitions used across the local module
- align local settings, model manager, and fine-tuning components with available icon names and corrected event typing

## Testing
- `npm run typecheck` *(fails: existing TypeScript errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cd24fd0de08329a7bfa6c5a42bcbff