### PR TITLE
Fix duplicate classNames exports

### DIFF
--- a/src/utils/unified/classNames.ts
+++ b/src/utils/unified/classNames.ts
@@ -1,22 +1,13 @@
 import { cn as mergeClassNames } from '../cn';
 
-export function classNames(
-  ...classes: Array<string | false | null | undefined>
-): string {
+type ClassValue = string | false | null | undefined;
+
+export function classNames(...classes: ClassValue[]): string {
   return mergeClassNames(...classes);
 }
 
-export function cn(
-  ...classes: Array<string | false | null | undefined>
-): string {
+export function cn(...classes: ClassValue[]): string {
   return classNames(...classes);
 }
 
-export function classNames(...classes: (string | undefined | null | false)[]): string {
-  return classes.filter(Boolean).join(' ');
-}
-
-export function cn(...classes: (string | undefined | null | false)[]): string {
-  return classNames(...classes);
-}
 export default classNames;


### PR DESCRIPTION
## Summary
- deduplicate the `classNames` and `cn` helpers in the unified utilities
- centralize the shared class value typing and reuse the existing `cn` implementation

## Testing
- npm run typecheck *(fails: existing TypeScript issues throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4aa6df6083298214ea6326852285