### PR TITLE
Fix ChatInput key handler typing

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useRef, useEffect } from 'react';
-import type { KeyboardEvent } from 'react';
 import {
   PaperAirplaneIcon,
   DocumentArrowUpIcon,
@@ -44,7 +43,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     }
   };
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyDown: React.KeyboardEventHandler<HTMLTextAreaElement> = (event) => {
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
       if (value.trim() && !disabled) {


### PR DESCRIPTION
## Summary
- ensure the chat input keydown handler uses React's `KeyboardEventHandler` typing to match the component signature
- remove the now-unnecessary standalone `KeyboardEvent` type import

## Testing
- npm run typecheck *(fails: pre-existing TypeScript errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4ade0c9483298a362c631eb23ef9