### PR TITLE
Fix MessageComponent keydown typing

### DIFF
--- a/src/components/chat/modern/MessageComponent.tsx
+++ b/src/components/chat/modern/MessageComponent.tsx
@@ -1,5 +1,4 @@
 import React, { useState, forwardRef, useRef, useEffect } from 'react';
-import type { KeyboardEvent } from 'react';
 import { Message } from '../../../types/chat';
 import ReactMarkdown from 'react-markdown';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
@@ -97,7 +96,7 @@ const MessageComponent = forwardRef<HTMLDivElement, MessageComponentProps>(({
     });
   };
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
       handleSaveEdit();


### PR DESCRIPTION
## Summary
- ensure the MessageComponent edit textarea uses React.KeyboardEvent for its keydown handler to match React's event types

## Testing
- npm run typecheck *(fails: pre-existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4b281f0c8329a0bd2cf9cca481ed