### PR TITLE
Fix drag event types in document upload

### DIFF
--- a/src/components/documents/DocumentUpload.tsx
+++ b/src/components/documents/DocumentUpload.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useRef } from 'react';
-import type { DragEvent } from 'react';
 import {
   CloudArrowUpIcon,
   DocumentTextIcon,
@@ -137,7 +136,7 @@ export const DocumentUpload: React.FC<DocumentUploadProps> = ({
     }
   };
 
-  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     setIsDragOver(false);
 
@@ -147,12 +146,12 @@ export const DocumentUpload: React.FC<DocumentUploadProps> = ({
     }
   };
 
-  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     setIsDragOver(true);
   };
 
-  const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
+  const handleDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     setIsDragOver(false);
   };


### PR DESCRIPTION
## Summary
- adjust drag event handler typings in DocumentUpload to use React's namespace

## Testing
- npm run typecheck *(fails: pre-existing type errors across codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4b3a289c832992eb12d96e17d675