### PR TITLE
Fix custom React types for error boundary support

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -528,11 +528,22 @@ declare module 'react' {
     type FormEventHandler<T = Element> = (event: FormEvent<T>) => void;
     type ChangeEventHandler<T = Element> = (event: ChangeEvent<T>) => void;
 
+    interface ErrorInfo {
+      componentStack: string;
+    }
+
     class Component<P = {}, S = {}, SS = any> {
-      constructor(props: P);
+      constructor(props: P, context?: any);
       props: Readonly<P>;
       state: Readonly<S>;
-      setState(state: Partial<S> | ((prevState: Readonly<S>) => Partial<S> | null)): void;
+      context: any;
+      refs: Record<string, any>;
+      setState(
+        state:
+          | Partial<S>
+          | ((prevState: Readonly<S>, props: Readonly<P>) => Partial<S> | null),
+        callback?: () => void
+      ): void;
       forceUpdate(callback?: () => void): void;
       render(): any;
     }
@@ -721,6 +732,8 @@ declare module 'react' {
     StrictMode: React.FunctionComponent<{ children?: React.ReactNode }>;
     Component: typeof React.Component;
   };
+
+  export type ErrorInfo = React.ErrorInfo;
 
   export = React;
 }


### PR DESCRIPTION
## Summary
- extend the locally overridden React type definitions to expose the ErrorInfo type required by the error boundary
- add missing context, refs, and improved setState signature to the custom React.Component declaration so class components remain valid JSX elements

## Testing
- `npm run typecheck` *(fails: existing project-wide type issues unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4b45bf0c83299bd51f05326dc664