### PR TITLE
Fix DocumentViewer type errors

### DIFF
--- a/src/components/files/DocumentViewer.tsx
+++ b/src/components/files/DocumentViewer.tsx
@@ -3,7 +3,7 @@
  * Displays parsed documents with search and navigation capabilities
  */
 
-import type { FC, KeyboardEvent } from 'react';
+import type { FC, KeyboardEventHandler } from 'react';
 import { useState, useEffect, useMemo } from 'react';
 import { StoredDocument } from '../../services/localStorage';
 
@@ -56,7 +56,7 @@ export const DocumentViewer: FC<DocumentViewerProps> = ({
     onTagUpdate?.(document!.id, updatedTags);
   };
 
-  const handleKeyPress = (event: KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyPress: KeyboardEventHandler<HTMLInputElement> = (event) => {
     if (event.key === 'Enter') {
       handleAddTag();
     }
@@ -145,7 +145,7 @@ export const DocumentViewer: FC<DocumentViewerProps> = ({
         </div>
         <div className="info-row">
           <span className="info-label">Last Accessed:</span>
-          <span className="info-value">{formatDate(document.lastAccessed)}</span>
+          <span className="info-value">{formatDate(document.metadata.lastAccessed)}</span>
         </div>
         <div className="info-row">
           <span className="info-label">Path:</span>


### PR DESCRIPTION
## Summary
- align the DocumentViewer tag entry handler with React's `KeyboardEventHandler` typing
- read the last accessed timestamp from the document metadata to stay within the `StoredDocument` type

## Testing
- npm run typecheck *(fails: hundreds of pre-existing TypeScript errors across the project unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4b4c8044832980aa372f4833d2e2