### PR TITLE
Fix legal chat typing indicator import

### DIFF
--- a/src/components/legal/LegalChatInterface.tsx
+++ b/src/components/legal/LegalChatInterface.tsx
@@ -17,7 +17,7 @@ import { LegalContextPanel } from './LegalContextPanel';
 import { LegalInputArea } from './LegalInputArea';
 import { LegalToolbar } from './LegalToolbar';
 import { LegalSettingsPanel } from './LegalSettingsPanel';
-import TypingIndicator from '../chat/modern/TypingIndicator';
+import { TypingIndicator } from '../streaming';
 import './LegalChatInterface.css';
 
 interface LegalChatInterfaceProps {


### PR DESCRIPTION
## Summary
- update the legal chat interface to use the streaming TypingIndicator export that supports the existing props

## Testing
- npm run typecheck *(fails: repository currently has numerous pre-existing TypeScript errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4bb2da188329ba1fa184f1c1c933