### PR TITLE
Fix legal research search options type

### DIFF
--- a/src/components/legal/LegalResearchInterface.tsx
+++ b/src/components/legal/LegalResearchInterface.tsx
@@ -126,13 +126,17 @@ export const LegalResearchInterface: React.FC<LegalResearchInterfaceProps> = ({
 
       // Perform search
       let results: ResearchResult[] = [];
+      const searchOptions: { jurisdictions?: string[] } =
+        filters.jurisdiction.length > 0
+          ? { jurisdictions: filters.jurisdiction }
+          : {};
 
       if (filters.documentType.includes('case')) {
         const cases = await researchService.searchCaseLaw(
           searchQuery,
-          filters.jurisdiction.length > 0 ? filters.jurisdiction : undefined
+          searchOptions
         );
-        
+
         results = results.concat(cases.map(caseData => ({
           id: caseData.id,
           type: 'case' as const,
@@ -150,7 +154,7 @@ export const LegalResearchInterface: React.FC<LegalResearchInterfaceProps> = ({
       if (filters.documentType.includes('statute')) {
         const statutes = await researchService.searchStatutes(
           searchQuery,
-          filters.jurisdiction.length > 0 ? filters.jurisdiction : undefined
+          searchOptions
         );
         
         results = results.concat(statutes.map(statute => ({


### PR DESCRIPTION
## Summary
- ensure the legal research interface passes structured search options into the service lookups
- reuse a single jurisdiction-aware options object for both case law and statute searches

## Testing
- npm run typecheck *(fails: existing TypeScript errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4bd456d08329bbbd454037873baa