### PR TITLE
Fix HuggingFace component export paths

### DIFF
--- a/src/components/model/huggingface/index.ts
+++ b/src/components/model/huggingface/index.ts
@@ -8,17 +8,17 @@ export { default as HuggingFaceModelSelector } from './HuggingFaceModelSelector'
 export { default as FineTuningInterface } from './FineTuningInterface';
 
 // Services
-export { default as HuggingFaceService } from '../../services/huggingface/HuggingFaceService';
-export { default as ModelSwitcher } from '../../services/huggingface/ModelSwitcher';
-export { default as LocalModelManager } from '../../services/huggingface/LocalModelManager';
+export { default as HuggingFaceService } from '../../../services/huggingface/HuggingFaceService';
+export { default as ModelSwitcher } from '../../../services/huggingface/ModelSwitcher';
+export { default as LocalModelManager } from '../../../services/huggingface/LocalModelManager';
 
 // Utilities
-export { default as ModelBenchmarking } from '../../utils/huggingface/ModelBenchmarking';
-export { default as CompatibilityValidator } from '../../utils/huggingface/CompatibilityValidator';
-export { default as HuggingFaceErrorHandler } from '../../utils/huggingface/ErrorHandler';
+export { default as ModelBenchmarking } from '../../../utils/huggingface/ModelBenchmarking';
+export { default as CompatibilityValidator } from '../../../utils/huggingface/CompatibilityValidator';
+export { default as HuggingFaceErrorHandler } from '../../../utils/huggingface/ErrorHandler';
 
 // Types
-export * from '../../types/huggingface';
+export * from '../../../types/huggingface';
 
 // Re-export for convenience
 export type {
@@ -30,4 +30,4 @@ export type {
   FineTuningCapabilities,
   ModelDownloadProgress,
   BenchmarkResult
-} from '../../types/huggingface';
+} from '../../../types/huggingface';


### PR DESCRIPTION
## Summary
- correct the HuggingFace index barrel exports to point at the services, utilities, and types folders under src

## Testing
- npm run typecheck *(fails: the repository currently has numerous pre-existing TypeScript errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4c312cec8329a3f6c9e170295f0f