### PR TITLE
Fix missing hero icon type declaration

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1136,6 +1136,7 @@ declare module '@heroicons/react/24/outline' {
   export const ArrowRightIcon: FC<IconProps>;
   export const ArrowUpIcon: FC<IconProps>;
   export const ArrowDownIcon: FC<IconProps>;
+  export const ArrowTopRightOnSquareIcon: FC<IconProps>;
   export const ArrowRightOnRectangleIcon: FC<IconProps>;
   export const PlusIcon: FC<IconProps>;
   export const MinusIcon: FC<IconProps>;


### PR DESCRIPTION
## Summary
- add the ArrowTopRightOnSquareIcon type export to the custom @heroicons/react/24/outline module declaration so the search results component can import it without errors

## Testing
- npm run typecheck *(fails: numerous pre-existing type errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4c4a729c8329a1192283fc0d5125