### PR TITLE
Fix web vitals import for v4

### DIFF
--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,13 +1,13 @@
-import { ReportHandler } from 'web-vitals';
+import type { ReportCallback } from 'web-vitals';
 
-const reportWebVitals = (onPerfEntry?: ReportHandler) => {
+const reportWebVitals = (onPerfEntry?: ReportCallback) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry);
-      getFID(onPerfEntry);
-      getFCP(onPerfEntry);
-      getLCP(onPerfEntry);
-      getTTFB(onPerfEntry);
+    import('web-vitals').then(({ onCLS, onFID, onFCP, onLCP, onTTFB }) => {
+      onCLS(onPerfEntry);
+      onFID(onPerfEntry);
+      onFCP(onPerfEntry);
+      onLCP(onPerfEntry);
+      onTTFB(onPerfEntry);
     });
   }
 };


### PR DESCRIPTION
## Summary
- update `reportWebVitals` to use the v4 web-vitals API and types
- load the new on* helpers when reporting vitals

## Testing
- npm run typecheck *(fails: pre-existing TypeScript errors across project)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4d390308832984f05a2e31e142ba