### PR TITLE
Fix plugin system event listener typing

### DIFF
--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -260,12 +260,12 @@ export class BearPluginSystem {
    */
 
   // Subscribe to system events
-  on(event: string, listener: Function): void {
+  on(event: string, listener: (...args: any[]) => void): void {
     this.manager.on(event, listener);
   }
 
   // Unsubscribe from system events
-  off(event: string, listener: Function): void {
+  off(event: string, listener: (...args: any[]) => void): void {
     this.manager.off(event, listener);
   }
 


### PR DESCRIPTION
## Summary
- align the BearPluginSystem `on` and `off` event listener signatures with the Node.js `EventEmitter` expectation so listeners match `(...args: any[]) => void`

## Testing
- `npm run typecheck` *(fails: existing 481 TypeScript errors across the repository unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4d25a9f48329a486ebdc229c167f