### PR TITLE
Fix plugin event handler typings

### DIFF
--- a/src/plugins/api/APIProvider.ts
+++ b/src/plugins/api/APIProvider.ts
@@ -11,6 +11,7 @@ import {
   PluginStorageAPI,
   PluginUIAPI,
   PluginEventAPI,
+  PluginEventHandler,
   PluginUtilsAPI,
   BearAIAPI,
   PluginConfigSchema,
@@ -388,11 +389,11 @@ export class PluginAPIProvider extends EventEmitter {
 
   private createEventAPI(pluginId: string): PluginEventAPI {
     const eventAPI: PluginEventAPI = {
-      on: (event: string, handler: Function) => {
+      on: (event: string, handler: PluginEventHandler) => {
         this.on(`plugin:${pluginId}:${event}`, handler);
       },
 
-      off: (event: string, handler: Function) => {
+      off: (event: string, handler: PluginEventHandler) => {
         this.off(`plugin:${pluginId}:${event}`, handler);
       },
 
@@ -401,7 +402,7 @@ export class PluginAPIProvider extends EventEmitter {
         this.emit('plugin:event', { pluginId, event, data });
       },
 
-      once: (event: string, handler: Function) => {
+      once: (event: string, handler: PluginEventHandler) => {
         this.once(`plugin:${pluginId}:${event}`, handler);
       }
     };

--- a/src/plugins/core/types.ts
+++ b/src/plugins/core/types.ts
@@ -111,11 +111,13 @@ export interface PluginUIAPI {
   removePanel(panelId: string): void;
 }
 
+export type PluginEventHandler = (...args: any[]) => void;
+
 export interface PluginEventAPI {
-  on(event: string, handler: Function): void;
-  off(event: string, handler: Function): void;
+  on(event: string, handler: PluginEventHandler): void;
+  off(event: string, handler: PluginEventHandler): void;
   emit(event: string, data?: any): void;
-  once(event: string, handler: Function): void;
+  once(event: string, handler: PluginEventHandler): void;
 }
 
 export interface PluginUtilsAPI {


### PR DESCRIPTION
## Summary
- add a dedicated PluginEventHandler type that matches EventEmitter expectations
- update the plugin API provider to use the stricter handler signature

## Testing
- `npm run typecheck` *(fails: repository currently has existing type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4d1b9f308329a95712ca1388543f