### PR TITLE
Fix platform return type cast for memory manager

### DIFF
--- a/src/integrations/cross-platform-memory.ts
+++ b/src/integrations/cross-platform-memory.ts
@@ -657,7 +657,7 @@ export class CrossPlatformMemoryManager {
   }
 
   getPlatform(): NodeJS.Platform {
-    return process.platform
+    return process.platform as NodeJS.Platform
   }
 
   static isMemoryOptimizationSupported(): boolean {


### PR DESCRIPTION
## Summary
- ensure the cross-platform memory manager returns a NodeJS.Platform by casting the detected process platform
- add the missing trailing newline to the module export

## Testing
- npm run typecheck *(fails: existing TypeScript errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4d071454832984e2ccd9dd99af7d