### PR TITLE
Fix heroicons import error in license activation component

### DIFF
--- a/src/licensing/frontend/components/LicenseActivation.tsx
+++ b/src/licensing/frontend/components/LicenseActivation.tsx
@@ -9,9 +9,9 @@ import {
   ComputerDesktopIcon,
   CheckCircleIcon,
   ExclamationCircleIcon,
-  ArrowRightIcon,
-  DocumentDuplicateIcon
+  ArrowRightIcon
 } from '@heroicons/react/24/outline';
+import { Copy } from 'lucide-react';
 import {
   LicenseActivationRequest,
   LicenseActivationResponse,
@@ -267,7 +267,7 @@ export const LicenseActivation: React.FC<LicenseActivationProps> = ({
                   onClick={() => copyToClipboard(hardwareFingerprint.fingerprint)}
                   className="ml-2 text-gray-400 hover:text-gray-600"
                 >
-                  <DocumentDuplicateIcon className="h-4 w-4" />
+                  <Copy className="h-4 w-4" />
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- replace the missing DocumentDuplicateIcon import by using the existing lucide-react Copy icon in the license activation UI

## Testing
- npm install *(fails: Invalid Version error from npm)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4c74a3b88329b8162e46c713d24a