### PR TITLE
Fix logging helpers and update context types

### DIFF
--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useReducer, useEffect } from 'react';
-import { User, SystemStatus, Chat, Document } from '../types';
+import { User, SystemStatus, Document, ChatSession } from '../types';
 
 // Combined state from both GUI variants
 export interface AppState {
@@ -23,8 +23,8 @@ export interface AppState {
   
   // Content state
   searchQuery: string;
-  activeChat: Chat | null;
-  recentChats: Chat[];
+  activeChat: ChatSession | null;
+  recentChats: ChatSession[];
   documents: Document[];
   
   // Loading states
@@ -40,9 +40,9 @@ type AppAction =
   | { type: 'SET_CURRENT_VIEW'; payload: string }
   | { type: 'SET_SYSTEM_STATUS'; payload: Partial<SystemStatus> }
   | { type: 'SET_SEARCH_QUERY'; payload: string }
-  | { type: 'SET_ACTIVE_CHAT'; payload: Chat | null }
-  | { type: 'SET_RECENT_CHATS'; payload: Chat[] }
-  | { type: 'ADD_CHAT'; payload: Chat }
+  | { type: 'SET_ACTIVE_CHAT'; payload: ChatSession | null }
+  | { type: 'SET_RECENT_CHATS'; payload: ChatSession[] }
+  | { type: 'ADD_CHAT'; payload: ChatSession }
   | { type: 'SET_DOCUMENTS'; payload: Document[] }
   | { type: 'ADD_DOCUMENT'; payload: Document }
   | { type: 'ADD_NOTIFICATION'; payload: { type: 'info' | 'success' | 'warning' | 'error'; title: string; message: string } }

--- a/src/contexts/PerformanceContext.tsx
+++ b/src/contexts/PerformanceContext.tsx
@@ -24,7 +24,9 @@ interface PerformanceContextType {
   suggestions: OptimizationSuggestion[];
 
   // Actions
-  recordModelInference: (metrics: Omit<ModelInferenceMetrics, 'tokensPerSecond'>) => void;
+  recordModelInference: (
+    metrics: Omit<ModelInferenceMetrics, 'tokensPerSecond' | 'success'> & { success?: boolean }
+  ) => void;
   recordUserInteraction: (metrics: UserInteractionMetrics) => void;
   resolveAlert: (alertId: string) => void;
 
@@ -136,7 +138,9 @@ export const PerformanceProvider: React.FC<PerformanceProviderProps> = ({
     performanceMonitor.stopMonitoring();
   };
 
-  const recordModelInference = (metrics: Omit<ModelInferenceMetrics, 'tokensPerSecond'>) => {
+  const recordModelInference = (
+    metrics: Omit<ModelInferenceMetrics, 'tokensPerSecond' | 'success'> & { success?: boolean }
+  ) => {
     performanceMonitor.recordModelInference(metrics);
   };
 
@@ -295,6 +299,8 @@ export const useModelTracking = () => {
         memoryUsed = (performance as any).memory.usedJSHeapSize - memoryBefore;
       }
 
+      const success = !error;
+
       performance.recordModelInference({
         modelId: modelName,
         requestId,
@@ -306,6 +312,7 @@ export const useModelTracking = () => {
         error,
         inputTokens: metadata?.inputTokens || 0,
         outputTokens: metadata?.outputTokens || tokensGenerated,
+        success,
         latency: {
           firstToken: Math.min(duration, 100), // Estimate first token latency
           totalTime: duration,


### PR DESCRIPTION
## Summary
- add contextual child logger support and structured component lifecycle helpers to the unified logger
- align the app context chat state with the exported ChatSession type
- update performance tracking to match the monitor API and record inference success metadata

## Testing
- npm run typecheck *(fails: repository currently has numerous pre-existing TypeScript errors outside the modified files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4ca2cf24832986092dbb931af094