### PR TITLE
Fix HuggingFace integration exports

### DIFF
--- a/src/components/model/huggingface/index.ts
+++ b/src/components/model/huggingface/index.ts
@@ -21,13 +21,14 @@ export { default as HuggingFaceErrorHandler } from '../../utils/huggingface/Erro
 export * from '../../types/huggingface';
 
 // Re-export for convenience
+export { LegalCategory } from '../../types/huggingface';
 export type {
   HuggingFaceModel,
   ModelSearchFilters,
-  LegalCategory,
   ModelRecommendation,
   CompatibilityResult,
   FineTuningCapabilities,
+  FineTuningConfig,
   ModelDownloadProgress,
   BenchmarkResult
 } from '../../types/huggingface';


### PR DESCRIPTION
## Summary
- re-export the LegalCategory enum as a runtime value from the HuggingFace component index
- include FineTuningConfig in the HuggingFace index type exports so the example and interfaces can import it

## Testing
- npm run typecheck *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4ca7a82c832990e25a706346eba8