### PR TITLE
Fix TypeScript utils path alias

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
       "@/components/*": ["src/components/*"],
       "@/types/*": ["src/types/*"],
       "@/utils/*": ["src/utils/*"],
+      "@utils/*": ["src/utils/*"],
       "@/hooks/*": ["src/hooks/*"],
       "@/contexts/*": ["src/contexts/*"],
       "@/services/*": ["src/services/*"],


### PR DESCRIPTION
## Summary
- add the missing `@utils/*` path alias so TypeScript can resolve imports such as `@utils/memoryMonitor`

## Testing
- `npm run typecheck` *(fails: pre-existing type errors across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4cd265a4832986bac6fe7ad768ec