### PR TITLE
Guard network interface iteration in license manager

### DIFF
--- a/src/licensing/backend/license.manager.ts
+++ b/src/licensing/backend/license.manager.ts
@@ -120,15 +120,19 @@ export class LicenseManager {
 
       // Get MAC address
       let macAddress = '';
-      for (const [name, interfaces] of Object.entries(networkInterfaces)) {
-        if (interfaces) {
-          for (const iface of interfaces) {
-            if (!iface.internal && iface.mac && iface.mac !== '00:00:00:00:00:00') {
-              macAddress = iface.mac;
-              break;
-            }
+      for (const name of Object.keys(networkInterfaces)) {
+        const interfaces = networkInterfaces[name];
+        if (!interfaces) {
+          continue;
+        }
+
+        for (const iface of interfaces) {
+          if (!iface.internal && iface.mac && iface.mac !== '00:00:00:00:00:00') {
+            macAddress = iface.mac;
+            break;
           }
         }
+
         if (macAddress) break;
       }
 


### PR DESCRIPTION
## Summary
- guard iteration over network interface entries to avoid iterating over unknown values when building the hardware fingerprint

## Testing
- npm run typecheck *(fails: existing repository TypeScript errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4ce123688329a5f5b20da1cfba33