### PR TITLE
Fix type inference for config file loading

### DIFF
--- a/src/services/environmentConfigLoader.ts
+++ b/src/services/environmentConfigLoader.ts
@@ -406,7 +406,7 @@ export class EnvironmentConfigLoader {
   }
 
   private async loadConfigFile(filePath: string, format: 'json' | 'yaml' | 'env'): Promise<any> {
-    const content = readFileSync(filePath, 'utf8');
+    const content = readFileSync(filePath, { encoding: 'utf8' });
 
     switch (format) {
       case 'json':


### PR DESCRIPTION
## Summary
- ensure environment config loader reads files with an explicit UTF-8 encoding object so TypeScript treats the contents as strings

## Testing
- npm run typecheck *(fails: existing TypeScript errors throughout the project unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4d597b848329abc319b4ef75b385