### PR TITLE
Fix HuggingFace model selector type mismatches

### DIFF
--- a/src/components/model/huggingface/HuggingFaceModelSelector.tsx
+++ b/src/components/model/huggingface/HuggingFaceModelSelector.tsx
@@ -387,13 +387,13 @@ const FilterPanel: React.FC<{
               <input
                 type="checkbox"
                 className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                checked={filters.licenses?.includes(license) || false}
+                checked={filters.license?.includes(license) || false}
                 onChange={(e) => {
-                  const current = filters.licenses || [];
+                  const current = filters.license || [];
                   const updated = e.target.checked
                     ? [...current, license]
                     : current.filter(l => l !== license);
-                  onFiltersChange({ ...filters, licenses: updated });
+                  onFiltersChange({ ...filters, license: updated });
                 }}
               />
               <span className="ml-2 text-sm text-gray-700">
@@ -461,8 +461,11 @@ export const HuggingFaceModelSelector: React.FC<HuggingFaceModelSelectorProps> =
     {
       id: 'legal-bert-base-uncased',
       modelId: 'nlpaueb/legal-bert-base-uncased',
+      name: 'Legal BERT Base Uncased',
       author: 'nlpaueb',
       sha: 'abc123',
+      created_at: '2023-01-15T00:00:00Z',
+      updated_at: '2023-06-20T00:00:00Z',
       createdAt: new Date('2023-01-15'),
       lastModified: new Date('2023-06-20'),
       downloads: 15420,

--- a/src/types/huggingface.ts
+++ b/src/types/huggingface.ts
@@ -13,8 +13,8 @@ export interface HuggingFaceModel {
   pipeline_tag?: string;
   library_name?: string;
   license?: string;
-  created_at: string;
-  updated_at: string;
+  created_at?: string;
+  updated_at?: string;
   size?: number;
   config?: Record<string, any>;
   tokenizer?: string;
@@ -26,6 +26,26 @@ export interface HuggingFaceModel {
   compatibilityInfo?: CompatibilityInfo;
   localStatus?: LocalModelStatus;
   bearaiTags?: string[];
+  /**
+   * Enhanced metadata used by BEAR AI's legal workflows
+   */
+  modelId?: string;
+  createdAt?: Date;
+  lastModified?: Date;
+  legalScore?: number;
+  legalUseCases?: LegalUseCase[];
+  performanceBenchmarks?: PerformanceBenchmark[];
+  fineTuningCapabilities?: FineTuningCapabilities;
+}
+
+export enum ModelSortOption {
+  RELEVANCE = 'relevance',
+  LEGAL_SCORE = 'legal_score',
+  DOWNLOADS = 'downloads',
+  LIKES = 'likes',
+  CREATED_AT = 'created_at',
+  LAST_MODIFIED = 'last_modified',
+  MODEL_SIZE = 'model_size'
 }
 
 export interface ModelSearchFilters {
@@ -40,17 +60,64 @@ export interface ModelSearchFilters {
   direction?: 'asc' | 'desc';
   limit?: number;
   full?: boolean;
+  legalCategories?: LegalCategory[];
+  minLegalScore?: number;
+  maxModelSize?: number;
+  requiresGpu?: boolean;
+  sortBy?: ModelSortOption;
+  sortOrder?: 'asc' | 'desc';
 }
 
-export type LegalCategory = 
-  | 'contract-analysis'
-  | 'legal-research'
-  | 'compliance-check'
-  | 'document-review'
-  | 'case-law-analysis'
-  | 'regulatory-compliance'
-  | 'risk-assessment'
-  | 'legal-drafting';
+export const LegalCategory = {
+  CONTRACT_ANALYSIS: 'contract-analysis',
+  LEGAL_RESEARCH: 'legal-research',
+  COMPLIANCE: 'compliance',
+  COMPLIANCE_CHECK: 'compliance-check',
+  DOCUMENT_REVIEW: 'document-review',
+  CASE_LAW_ANALYSIS: 'case-law-analysis',
+  REGULATORY_ANALYSIS: 'regulatory-analysis',
+  REGULATORY_COMPLIANCE: 'regulatory-compliance',
+  RISK_ASSESSMENT: 'risk-assessment',
+  LEGAL_DRAFTING: 'legal-drafting',
+  LITIGATION_SUPPORT: 'litigation-support',
+  INTELLECTUAL_PROPERTY: 'intellectual-property',
+  CORPORATE_LAW: 'corporate-law',
+  CRIMINAL_LAW: 'criminal-law',
+  FAMILY_LAW: 'family-law',
+  IMMIGRATION_LAW: 'immigration-law',
+  TAX_LAW: 'tax-law',
+  REAL_ESTATE: 'real-estate',
+  EMPLOYMENT_LAW: 'employment-law',
+  GENERAL_LEGAL: 'general-legal'
+} as const;
+
+export type LegalCategory = typeof LegalCategory[keyof typeof LegalCategory];
+
+export interface LegalUseCase {
+  id: string;
+  name: string;
+  description: string;
+  category: LegalCategory;
+  suitabilityScore: number;
+  examples: string[];
+  requirements: string[];
+  limitations: string[];
+  accuracy?: number;
+  speed?: number;
+  resourceIntensive?: boolean;
+}
+
+export interface PerformanceBenchmark {
+  taskType: string;
+  taskName: string;
+  dataset: string;
+  metric: string;
+  score: number;
+  lastTested: Date;
+  testingFramework: string;
+  notes?: string;
+  legalRelevance?: number;
+}
 
 export interface ModelRecommendation {
   model: HuggingFaceModel;
@@ -75,6 +142,7 @@ export interface CompatibilityResult {
     computeCapability?: string;
   };
   recommendations: string[];
+  score?: number;
 }
 
 export interface ResourceRequirements {


### PR DESCRIPTION
## Summary
- extend the HuggingFace type definitions to expose legal metadata, sort options, and compatibility scores required by the selector UI
- update the HuggingFace model selector filters and sample data to align with the revised types

## Testing
- npm run typecheck *(fails: existing TypeScript errors throughout the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cd58de7930832993a9b5b15be1ad2b