### PR TITLE
Fix TypeScript type compatibility for drag and keyboard handlers

### DIFF
--- a/src/components/documents/DocumentUpload.tsx
+++ b/src/components/documents/DocumentUpload.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useRef } from 'react';
+import { useState, useRef } from 'react';
+import type { FC, DragEvent, ChangeEvent } from 'react';
 import {
   CloudArrowUpIcon,
   DocumentTextIcon,
@@ -12,7 +13,7 @@ interface DocumentUploadProps {
   acceptedTypes?: string[];
 }
 
-export const DocumentUpload: React.FC<DocumentUploadProps> = ({
+export const DocumentUpload: FC<DocumentUploadProps> = ({
   onUpload,
   maxSize = 50 * 1024 * 1024, // 50MB default
   acceptedTypes = ['.pdf', '.doc', '.docx', '.txt', '.rtf']
@@ -136,7 +137,7 @@ export const DocumentUpload: React.FC<DocumentUploadProps> = ({
     }
   };
 
-  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     setIsDragOver(false);
 
@@ -146,17 +147,17 @@ export const DocumentUpload: React.FC<DocumentUploadProps> = ({
     }
   };
 
-  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     setIsDragOver(true);
   };
 
-  const handleDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
+  const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     setIsDragOver(false);
   };
 
-  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileSelect = (e: ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (files && files.length > 0) {
       handleFiles(files);

--- a/src/components/files/DocumentViewer.tsx
+++ b/src/components/files/DocumentViewer.tsx
@@ -3,7 +3,8 @@
  * Displays parsed documents with search and navigation capabilities
  */
 
-import type { FC, KeyboardEventHandler } from 'react';
+import type { FC } from 'react';
+import type React from 'react';
 import { useState, useEffect, useMemo } from 'react';
 import { StoredDocument } from '../../services/localStorage';
 
@@ -63,7 +64,7 @@ export const DocumentViewer: FC<DocumentViewerProps> = ({
     onTagUpdate?.(document!.id, updatedTags);
   };
 
-  const handleKeyPress: KeyboardEventHandler<HTMLInputElement> = (event) => {
+  const handleKeyPress: React.KeyboardEventHandler<HTMLInputElement> = (event) => {
     if (event.key === 'Enter') {
       handleAddTag();
     }

--- a/src/components/files/FileUploadProcessor.tsx
+++ b/src/components/files/FileUploadProcessor.tsx
@@ -3,7 +3,8 @@
  * Handles batch file upload and processing workflows
  */
 
-import React, { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
+import type { FC, DragEvent, ChangeEvent } from 'react';
 import { localFileSystemService, LocalFile } from '../../services/localFileSystem';
 import { documentParserService, ParsedDocument } from '../../services/documentParser';
 import { localStorageService, StoredDocument } from '../../services/localStorage';
@@ -26,7 +27,7 @@ interface FileUploadProcessorProps {
   acceptedTypes?: string[];
 }
 
-export const FileUploadProcessor: React.FC<FileUploadProcessorProps> = ({
+export const FileUploadProcessor: FC<FileUploadProcessorProps> = ({
   onJobComplete,
   onAllJobsComplete,
   onError,
@@ -106,13 +107,13 @@ export const FileUploadProcessor: React.FC<FileUploadProcessorProps> = ({
     }
   }, [jobs, activeJobs, maxConcurrentJobs, processJob]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (autoProcess && jobs.some(job => job.status === 'pending') && activeJobs.size < maxConcurrentJobs) {
       processQueue();
     }
   }, [jobs, activeJobs, autoProcess, maxConcurrentJobs, processQueue]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const completedJobs = jobs.filter(job => job.status === 'completed' || job.status === 'failed');
     if (completedJobs.length > 0 && completedJobs.length === jobs.length) {
       onAllJobsComplete?.(jobs);
@@ -166,7 +167,7 @@ export const FileUploadProcessor: React.FC<FileUploadProcessorProps> = ({
     }
   };
 
-  const handleDrop = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+  const handleDrop = useCallback((event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     setIsDragOver(false);
     dragCounterRef.current = 0;
@@ -175,11 +176,11 @@ export const FileUploadProcessor: React.FC<FileUploadProcessorProps> = ({
     handleFileSelection(files);
   }, [handleFileSelection]);
 
-  const handleDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+  const handleDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
   }, []);
 
-  const handleDragEnter = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+  const handleDragEnter = useCallback((event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     dragCounterRef.current++;
     if (dragCounterRef.current === 1) {
@@ -187,7 +188,7 @@ export const FileUploadProcessor: React.FC<FileUploadProcessorProps> = ({
     }
   }, []);
 
-  const handleDragLeave = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+  const handleDragLeave = useCallback((event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     dragCounterRef.current--;
     if (dragCounterRef.current === 0) {
@@ -195,7 +196,7 @@ export const FileUploadProcessor: React.FC<FileUploadProcessorProps> = ({
     }
   }, []);
 
-  const handleFileInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileInputChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
     handleFileSelection(files);
     

--- a/src/components/legal/LegalInputArea.tsx
+++ b/src/components/legal/LegalInputArea.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useRef, forwardRef, useImperativeHandle, useEffect } from 'react';
+import { useState, useRef, forwardRef, useImperativeHandle, useEffect } from 'react';
+import type { KeyboardEvent, ChangeEvent } from 'react';
 import { PracticeArea, Jurisdiction } from '../../types/legal';
 import './LegalInputArea.css';
 
@@ -146,7 +147,7 @@ export const LegalInputArea = forwardRef<HTMLTextAreaElement, LegalInputAreaProp
   };
 
   // Handle key press
-  const handleKeyPress = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyPress = (event: KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
       handleSend();
@@ -196,7 +197,7 @@ export const LegalInputArea = forwardRef<HTMLTextAreaElement, LegalInputAreaProp
   };
 
   // Handle file upload
-  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileUpload = (e: ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (files && files.length > 0) {
       const file = files[0];

--- a/src/components/model/huggingface/FineTuningInterface.tsx
+++ b/src/components/model/huggingface/FineTuningInterface.tsx
@@ -3,8 +3,9 @@
  * Comprehensive interface for fine-tuning HuggingFace models for legal tasks
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
-import type { DragEventHandler } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import type { FC, ChangeEvent } from 'react';
+import type React from 'react';
 import {
   PlayIcon,
   StopIcon,
@@ -14,7 +15,7 @@ import {
   Cog6ToothIcon,
   ExclamationCircleIcon,
   CheckCircleIcon,
-  ArrowUpTrayIcon,
+  ArrowUpIcon,
   CloudArrowDownIcon,
   BeakerIcon,
   AcademicCapIcon
@@ -51,7 +52,7 @@ interface TrainingConfigProps {
   onChange: (config: FineTuningConfig) => void;
 }
 
-const DatasetUpload: React.FC<DatasetUploadProps> = ({
+const DatasetUpload: FC<DatasetUploadProps> = ({
   onDatasetUpload,
   onDatasetValidate,
   acceptedFormats,
@@ -62,13 +63,13 @@ const DatasetUpload: React.FC<DatasetUploadProps> = ({
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
   const [validationResult, setValidationResult] = useState<{ valid: boolean; issues: string[] } | null>(null);
 
-  const handleDragEnter: DragEventHandler<HTMLDivElement> = (event) => {
+  const handleDragEnter: React.DragEventHandler<HTMLDivElement> = (event) => {
     event.preventDefault();
     event.stopPropagation();
     setDragActive(true);
   };
 
-  const handleDragOver: DragEventHandler<HTMLDivElement> = (event) => {
+  const handleDragOver: React.DragEventHandler<HTMLDivElement> = (event) => {
     event.preventDefault();
     event.stopPropagation();
     if (!dragActive) {
@@ -76,13 +77,13 @@ const DatasetUpload: React.FC<DatasetUploadProps> = ({
     }
   };
 
-  const handleDragLeave: DragEventHandler<HTMLDivElement> = (event) => {
+  const handleDragLeave: React.DragEventHandler<HTMLDivElement> = (event) => {
     event.preventDefault();
     event.stopPropagation();
     setDragActive(false);
   };
 
-  const handleDrop: DragEventHandler<HTMLDivElement> = (event) => {
+  const handleDrop: React.DragEventHandler<HTMLDivElement> = (event) => {
     event.preventDefault();
     event.stopPropagation();
     setDragActive(false);
@@ -92,7 +93,7 @@ const DatasetUpload: React.FC<DatasetUploadProps> = ({
     }
   };
 
-  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileSelect = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
       handleFile(e.target.files[0]);
     }
@@ -150,7 +151,7 @@ const DatasetUpload: React.FC<DatasetUploadProps> = ({
           onDragOver={handleDragOver}
           onDrop={handleDrop}
         >
-          <ArrowUpTrayIcon className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+          <ArrowUpIcon className="w-12 h-12 text-gray-400 mx-auto mb-4" />
           <p className="text-lg font-medium text-gray-900 mb-2">
             Drop your dataset here
           </p>
@@ -241,7 +242,7 @@ const DatasetUpload: React.FC<DatasetUploadProps> = ({
   );
 };
 
-const TrainingConfig: React.FC<TrainingConfigProps> = ({
+const TrainingConfig: FC<TrainingConfigProps> = ({
   config,
   capabilities,
   onChange
@@ -491,7 +492,7 @@ const TrainingConfig: React.FC<TrainingConfigProps> = ({
   );
 };
 
-const JobProgress: React.FC<{
+const JobProgress: FC<{
   job: FineTuningJob;
   onCancel: () => void;
   onPause: () => void;
@@ -671,7 +672,7 @@ const JobProgress: React.FC<{
   );
 };
 
-export const FineTuningInterface: React.FC<FineTuningInterfaceProps> = ({
+export const FineTuningInterface: FC<FineTuningInterfaceProps> = ({
   model,
   onJobCreate,
   onJobCancel,
@@ -787,9 +788,7 @@ export const FineTuningInterface: React.FC<FineTuningInterfaceProps> = ({
         dataset: 'uploaded-dataset.json',
         config,
         progress: 0,
-        startTime: new Date(),
-        retryCount: 0,
-        maxRetries: 3
+        startTime: new Date()
       };
       
       setActiveJobs(prev => [...prev, newJob]);


### PR DESCRIPTION
## Summary
- Align drag-and-drop and keyboard handler typings across upload and input components with the React type exports used by JSX to resolve TS2322 errors
- Update the HuggingFace fine-tuning interface to use an available heroicon, adopt consistent drag event handlers, and remove unsupported retry metadata from mock jobs

## Testing
- Not run (node modules unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd59744ea08329ba3d45d935dc9087