### PR TITLE
Fix memory monitor aliases and Node buffer typing

### DIFF
--- a/src/licensing/crypto/license.crypto.ts
+++ b/src/licensing/crypto/license.crypto.ts
@@ -87,8 +87,8 @@ export class LicenseCrypto {
    * Encrypt sensitive license data
   */
   static encryptLicenseData(data: string, password: string): { encrypted: string; iv: string; salt: string } {
-    const salt = crypto.randomBytes(16);
-    const iv = crypto.randomBytes(16);
+    const salt = crypto.randomBytes(16) as Buffer;
+    const iv = crypto.randomBytes(16) as Buffer;
     const key = crypto.pbkdf2Sync(password, salt, 10000, 32, 'sha256');
 
     const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
@@ -97,7 +97,7 @@ export class LicenseCrypto {
     let encrypted = cipher.update(data, 'utf8', 'hex');
     encrypted += cipher.final('hex');
 
-    const authTag = cipher.getAuthTag();
+    const authTag = cipher.getAuthTag() as Buffer;
 
     return {
       encrypted: encrypted + authTag.toString('hex'),
@@ -137,7 +137,7 @@ export class LicenseCrypto {
   static generateActivationCode(): string {
     const segments = [];
     for (let i = 0; i < 4; i++) {
-      const segment = crypto.randomBytes(2).toString('hex').toUpperCase();
+      const segment = (crypto.randomBytes(2) as Buffer).toString('hex').toUpperCase();
       segments.push(segment);
     }
     return segments.join('-');
@@ -189,8 +189,8 @@ export class LicenseCrypto {
    * Obfuscate license data for storage
    */
   static obfuscateLicenseData(licenseData: string): string {
-    const key = crypto.randomBytes(32);
-    const iv = crypto.randomBytes(16);
+    const key = crypto.randomBytes(32) as Buffer;
+    const iv = crypto.randomBytes(16) as Buffer;
 
     const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
     const encryptedBuffer = Buffer.concat([
@@ -199,7 +199,7 @@ export class LicenseCrypto {
     ]);
 
     // Store key and IV with encrypted data in a way that's not immediately obvious
-    const combined = Buffer.concat([
+    const combined: Buffer = Buffer.concat([
       key,
       iv,
       encryptedBuffer
@@ -219,7 +219,7 @@ export class LicenseCrypto {
       const encrypted = combined.slice(48);
 
       const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
-      const decryptedBuffer = Buffer.concat([
+      const decryptedBuffer: Buffer = Buffer.concat([
         decipher.update(encrypted),
         decipher.final()
       ]);

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1321,7 +1321,27 @@ declare module '@hooks/useMemoryMonitor' {
 }
 
 declare module '@utils/systemResources' {
-  export function getSystemResources(): any;
+  export interface SystemInfo {
+    platform: string;
+    cores: number;
+    memory?: number;
+    deviceMemory?: number;
+    connection?: string;
+    userAgent?: string;
+    language?: string;
+  }
+
+  export interface OptimalSystemConfig {
+    memoryMonitorInterval: number;
+    enableDetailedMetrics: boolean;
+    historySize: number;
+    smoothingFactor: number;
+    maxSamples: number;
+    adaptiveSampling: boolean;
+  }
+
+  export function getSystemInfo(): SystemInfo;
+  export function getOptimalConfig(systemInfo?: SystemInfo): OptimalSystemConfig;
 }
 
 declare module '@utils/cn' {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -29,6 +29,7 @@
       "@/components/*": ["src/components/*"],
       "@/types/*": ["src/types/*"],
       "@/utils/*": ["src/utils/*"],
+      "@utils/*": ["src/utils/*"],
       "@/hooks/*": ["src/hooks/*"],
       "@/contexts/*": ["src/contexts/*"],
       "@/services/*": ["src/services/*"],


### PR DESCRIPTION
## Summary
- add the @utils/* path mapping to the build TypeScript configuration so the memory monitor hook resolves shared utilities
- update the global system resources module declaration to expose the actual API used by hooks
- cast Node crypto outputs to Buffer when required so encode/decode helpers accept encoding arguments

## Testing
- npm run typecheck:build *(fails: pre-existing project type errors outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5964ae7c8329ae279777afa5469c