### PR TITLE
Fix React handler typing and update HuggingFace example

### DIFF
--- a/src/components/streaming/StreamingChat.tsx
+++ b/src/components/streaming/StreamingChat.tsx
@@ -125,13 +125,6 @@ export const StreamingChat: React.FC<StreamingChatProps> = ({
     }
   }, [inputValue, isConnected, isStreaming, streamMessage, streamingOptions, maxMessages, onMessageSent, onMessageReceived]);
 
-  const handleKeyPress: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleSendMessage();
-    }
-  };
-
   const getCurrentStreamingMessage = (): IStreamingMessage | null => {
     if (!isStreaming || !currentMessage) return null;
     
@@ -213,7 +206,12 @@ export const StreamingChat: React.FC<StreamingChatProps> = ({
               type="text"
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
-              onKeyPress={handleKeyPress}
+              onKeyPress={(event) => {
+                if (event.key === 'Enter' && !event.shiftKey) {
+                  event.preventDefault();
+                  handleSendMessage();
+                }
+              }}
               disabled={isInputDisabled || !isConnected}
               placeholder={
                 !isConnected 

--- a/src/components/ui/ModelSelector.tsx
+++ b/src/components/ui/ModelSelector.tsx
@@ -290,7 +290,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
           </Badge>
           <Badge
             variant={
-              [ModelStatus.LOADED, ModelStatus.ACTIVE].includes(model.status)
+              model.status === ModelStatus.LOADED || model.status === ModelStatus.ACTIVE
                 ? 'default'
                 : 'secondary'
             }

--- a/src/components/ui/StreamingChatInterface.tsx
+++ b/src/components/ui/StreamingChatInterface.tsx
@@ -200,9 +200,14 @@ const ChatInput: React.FC<ChatInputProps> = ({
   const fileInputRef = useRef<HTMLInputElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault()
+  type DropHandler = NonNullable<JSX.IntrinsicElements['div']['onDrop']>
+  type DragOverHandler = NonNullable<JSX.IntrinsicElements['div']['onDragOver']>
+  type DragLeaveHandler = NonNullable<JSX.IntrinsicElements['div']['onDragLeave']>
+  type TextareaKeyHandler = NonNullable<JSX.IntrinsicElements['textarea']['onKeyDown']>
+
+  const handleKeyDown: TextareaKeyHandler = (event) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault()
       if (value.trim() && !disabled) {
         onSend(value, attachments)
       }
@@ -219,19 +224,19 @@ const ChatInput: React.FC<ChatInputProps> = ({
     onAttachmentsChange([...attachments, ...newFiles])
   }
 
-  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault()
+  const handleDrop: DropHandler = (event) => {
+    event.preventDefault()
     setIsDragOver(false)
-    handleFileSelect(e.dataTransfer.files)
+    handleFileSelect(event.dataTransfer.files)
   }
 
-  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault()
+  const handleDragOver: DragOverHandler = (event) => {
+    event.preventDefault()
     setIsDragOver(true)
   }
 
-  const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault()
+  const handleDragLeave: DragLeaveHandler = (event) => {
+    event.preventDefault()
     setIsDragOver(false)
   }
 

--- a/src/components/ui/VirtualScrollList.tsx
+++ b/src/components/ui/VirtualScrollList.tsx
@@ -198,17 +198,19 @@ export const VirtualScrollList = React.forwardRef<VirtualScrollHandle, VirtualSc
   }, [scrollTop, calculateVisibleRange]);
   
   // Scroll handler with performance optimizations
-  const handleScroll = useCallback((event: React.UIEvent<Element>) => {
+  type ScrollHandler = NonNullable<JSX.IntrinsicElements['div']['onScroll']>
+
+  const handleScroll = useCallback<ScrollHandler>((event) => {
     const target = event.currentTarget as HTMLDivElement;
     const newScrollTop = target.scrollTop;
 
     setScrollTop(newScrollTop);
     setIsScrolling(true);
     debouncedScrollEnd();
-    
+
     // Call external scroll handler
     onScroll?.(newScrollTop);
-    
+
     // Check for end reached
     if (onEndReached && !loading) {
       const scrollRatio = (newScrollTop + containerHeight) / totalHeight;

--- a/src/services/huggingface/HuggingFaceService.ts
+++ b/src/services/huggingface/HuggingFaceService.ts
@@ -10,7 +10,8 @@ import {
   ModelRecommendation,
   HuggingFaceConfig,
   ModelMetadata,
-  ModelDownloadProgress
+  ModelDownloadProgress,
+  CompatibilityResult
 } from '../../types/huggingface';
 
 export class HuggingFaceService {
@@ -312,17 +313,28 @@ export class HuggingFaceService {
     return reasons;
   }
 
-  private async checkCompatibility(model: HuggingFaceModel): Promise<any> {
+  private async checkCompatibility(model: HuggingFaceModel): Promise<CompatibilityResult> {
     // Simplified compatibility check
     return {
       compatible: true,
+      score: 85,
+      confidence: 70,
       issues: [],
       warnings: [],
       requirements: {
         memory: 4000000000, // 4GB
         diskSpace: 2000000000, // 2GB
+        computeCapability: 'moderate'
       },
-      recommendations: ['Ensure adequate memory is available']
+      recommendations: ['Ensure adequate memory is available'],
+      optimizations: [
+        {
+          id: 'review-memory-usage',
+          description: 'Monitor memory usage during initial deployments.',
+          automated: false,
+          impact: 'medium'
+        }
+      ]
     };
   }
 

--- a/src/types/huggingface.ts
+++ b/src/types/huggingface.ts
@@ -42,15 +42,18 @@ export interface ModelSearchFilters {
   full?: boolean;
 }
 
-export type LegalCategory = 
-  | 'contract-analysis'
-  | 'legal-research'
-  | 'compliance-check'
-  | 'document-review'
-  | 'case-law-analysis'
-  | 'regulatory-compliance'
-  | 'risk-assessment'
-  | 'legal-drafting';
+export const LegalCategory = {
+  CONTRACT_ANALYSIS: 'contract_analysis',
+  LEGAL_RESEARCH: 'legal_research',
+  COMPLIANCE_CHECK: 'compliance_check',
+  DOCUMENT_REVIEW: 'document_review',
+  CASE_LAW_ANALYSIS: 'case_law_analysis',
+  REGULATORY_COMPLIANCE: 'regulatory_compliance',
+  RISK_ASSESSMENT: 'risk_assessment',
+  LEGAL_DRAFTING: 'legal_drafting'
+} as const;
+
+export type LegalCategory = typeof LegalCategory[keyof typeof LegalCategory];
 
 export interface ModelRecommendation {
   model: HuggingFaceModel;
@@ -65,8 +68,18 @@ export interface ModelRecommendation {
   };
 }
 
+export interface CompatibilityOptimization {
+  id: string;
+  description: string;
+  automated: boolean;
+  impact: 'low' | 'medium' | 'high';
+  estimatedImprovement?: number;
+}
+
 export interface CompatibilityResult {
   compatible: boolean;
+  score: number;
+  confidence: number;
   issues: string[];
   warnings: string[];
   requirements: {
@@ -75,6 +88,7 @@ export interface CompatibilityResult {
     computeCapability?: string;
   };
   recommendations: string[];
+  optimizations: CompatibilityOptimization[];
 }
 
 export interface ResourceRequirements {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -29,6 +29,7 @@
       "@/components/*": ["src/components/*"],
       "@/types/*": ["src/types/*"],
       "@/utils/*": ["src/utils/*"],
+      "@utils/*": ["src/utils/*"],
       "@/hooks/*": ["src/hooks/*"],
       "@/contexts/*": ["src/contexts/*"],
       "@/services/*": ["src/services/*"],


### PR DESCRIPTION
## Summary
- inline or re-type React event handlers to avoid mismatched type modules in streaming and UI components
- add the `@utils/*` path mapping for the build config and align HuggingFace compatibility types/service helpers
- refresh the HuggingFace integration example to use the available manager/service APIs and present realistic benchmark feedback

## Testing
- `npm run typecheck` *(fails: existing repository-wide TypeScript errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68cd596cf15083298d93f51431ee075f