### PR TITLE
Fix HuggingFace type definitions

### DIFF
--- a/src/types/huggingface.ts
+++ b/src/types/huggingface.ts
@@ -119,28 +119,6 @@ export interface CompatibilityResult {
   };
   recommendations: string[];
   optimizations: CompatibilityOptimization[];
-
-  export interface CompatibilityOptimization {
-  id: string;
-  description: string;
-  automated: boolean;
-  impact: 'low' | 'medium' | 'high';
-  estimatedImprovement?: number;
-}
-
-export interface CompatibilityResult {
-  compatible: boolean;
-  score: number;
-  confidence: number;
-  issues: string[];
-  warnings: string[];
-  requirements: {
-    memory: number;
-    diskSpace: number;
-    computeCapability?: string;
-  };
-  recommendations: string[];
-  optimizations: CompatibilityOptimization[];
 }
 
 export interface ResourceRequirements {
@@ -166,3 +144,137 @@ export interface CompatibilityInfo {
   frameworks?: string[];
   pythonVersions?: string[];
   transformersVersion?: string;
+  torchVersions?: string[];
+  tensorflowVersions?: string[];
+  onnxSupport?: boolean;
+  quantizationSupport?: {
+    int8?: boolean;
+    int4?: boolean;
+    fp16?: boolean;
+    bfloat16?: boolean;
+  };
+  platforms?: string[];
+  architectures?: string[];
+  specialRequirements?: string[];
+}
+
+export interface LocalModelStatus {
+  downloaded: boolean;
+  downloadProgress?: number;
+  downloadSpeed?: number;
+  estimatedTimeRemaining?: number;
+  localPath?: string;
+  localSize?: number;
+  lastUsed?: Date;
+  usage?: {
+    totalInferences: number;
+    totalTokens: number;
+    averageResponseTime: number;
+    errorCount: number;
+    successRate: number;
+  };
+  configuration?: Record<string, any>;
+}
+
+export interface ModelFile {
+  filename: string;
+  size?: number;
+  checksum?: string;
+  compressed?: boolean;
+}
+
+export interface FineTuningCapabilities {
+  supportsFineTuning: boolean;
+  supportedMethods: ('full' | 'lora' | 'qlora' | 'prefix-tuning')[];
+  maxSequenceLength: number;
+  recommendedBatchSize: number;
+  estimatedTrainingTime: {
+    small: number; // hours
+    medium: number;
+    large: number;
+  };
+  requirements: {
+    minMemory: number;
+    recommendedMemory: number;
+    gpuRequired: boolean;
+  };
+}
+
+export interface ModelDownloadProgress {
+  modelId: string;
+  status?: 'pending' | 'downloading' | 'extracting' | 'completed' | 'error';
+  progress: number; // 0-100
+  downloadedBytes?: number;
+  totalBytes?: number;
+  downloaded?: number;
+  total?: number;
+  speed: number; // bytes per second
+  eta: number; // estimated time remaining in seconds
+  error?: string;
+  files?: Array<{
+    filename: string;
+    progress: number;
+    size: number;
+    downloaded?: number;
+    checksum?: string;
+  }>;
+}
+
+export interface BenchmarkResult {
+  modelId: string;
+  timestamp: Date;
+  metrics: {
+    latency: {
+      mean: number;
+      p50: number;
+      p90: number;
+      p99: number;
+    };
+    throughput: {
+      tokensPerSecond: number;
+      requestsPerSecond: number;
+    };
+    accuracy: {
+      score: number;
+      dataset: string;
+      metric: string;
+    };
+    resources: {
+      memoryUsage: number;
+      cpuUsage: number;
+      gpuUsage?: number;
+    };
+    sequenceLength: number;
+    numSamples: number;
+    hardware: string;
+  };
+}
+
+export interface HuggingFaceConfig {
+  apiKey?: string;
+  baseUrl?: string;
+  timeout?: number;
+  retries?: number;
+  cacheTTL?: number;
+  localCacheEnabled?: boolean;
+  downloadPath?: string;
+}
+
+export interface ModelMetadata {
+  lastUpdated: Date;
+  localPath?: string;
+  isLocal: boolean;
+  version: string;
+  checksum?: string;
+  tags: string[];
+  customConfig?: Record<string, any>;
+}
+
+export interface HuggingFaceError {
+  code: string;
+  message: string;
+  details?: any;
+  retryable: boolean;
+  suggestion?: string;
+  stack?: string;
+}


### PR DESCRIPTION
## Summary
- restore the full HuggingFace type definitions that were truncated
- remove duplicated nested CompatibilityResult declarations and add the missing supporting interfaces
- extend CompatibilityInfo with the prior fields for frameworks, quantization support, and platform metadata

## Testing
- `npm run typecheck` *(fails: repository currently has numerous pre-existing TypeScript errors outside the changed file)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5f7e87648329a5a8cda12ab1611a