### PR TITLE
Fix TypeScript buffer conversions and config loader string parsing

### DIFF
--- a/src/licensing/crypto/license.crypto.ts
+++ b/src/licensing/crypto/license.crypto.ts
@@ -98,9 +98,9 @@ export class LicenseCrypto {
     encrypted += cipher.final('hex');
 
     const authTag = cipher.getAuthTag();
-    const authTagHex = authTag.toString('hex');
-    const ivHex = iv.toString('hex');
-    const saltHex = salt.toString('hex');
+    const authTagHex = Buffer.from(authTag).toString('hex');
+    const ivHex = Buffer.from(iv).toString('hex');
+    const saltHex = Buffer.from(salt).toString('hex');
 
     return {
       encrypted: encrypted + authTagHex,
@@ -138,10 +138,10 @@ export class LicenseCrypto {
    * Generate activation code
    */
   static generateActivationCode(): string {
-    const segments = [];
+    const segments: string[] = [];
     for (let i = 0; i < 4; i++) {
       const segmentBytes = crypto.randomBytes(2);
-      const segment = segmentBytes.toString('hex').toUpperCase();
+      const segment = Buffer.from(segmentBytes).toString('hex').toUpperCase();
       segments.push(segment);
     }
     return segments.join('-');
@@ -203,13 +203,13 @@ export class LicenseCrypto {
     ]);
 
     // Store key and IV with encrypted data in a way that's not immediately obvious
-    const combined: Buffer = Buffer.concat([
+    const combined = Buffer.concat([
       key,
       iv,
       encryptedBuffer
     ]);
 
-    return combined.toString('base64');
+    return Buffer.from(combined).toString('base64');
   }
 
   /**
@@ -223,7 +223,7 @@ export class LicenseCrypto {
       const encrypted = combined.slice(48);
 
       const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
-      const decryptedBuffer: Buffer = Buffer.concat([
+      const decryptedBuffer = Buffer.concat([
         decipher.update(encrypted),
         decipher.final()
       ]);

--- a/src/services/environmentConfigLoader.ts
+++ b/src/services/environmentConfigLoader.ts
@@ -406,7 +406,7 @@ export class EnvironmentConfigLoader {
   }
 
   private async loadConfigFile(filePath: string, format: 'json' | 'yaml' | 'env'): Promise<any> {
-    const content = readFileSync(filePath, 'utf8');
+    const content: string = readFileSync(filePath, { encoding: 'utf8' });
 
     switch (format) {
       case 'json':


### PR DESCRIPTION
## Summary
- normalize Buffer handling in the licensing crypto utilities so TypeScript accepts hex/base64 conversions
- ensure activation code generation works with an explicitly typed segments array
- read configuration files with an explicit UTF-8 encoding object so the loader receives a pure string

## Testing
- npm run typecheck *(fails: existing sandbox, config manager, and module declaration errors outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8b6ae3688329b7d080dba93c2169