### PR TITLE
fix: ensure config loader reads UTF-8 as string

### DIFF
--- a/src/services/environmentConfigLoader.ts
+++ b/src/services/environmentConfigLoader.ts
@@ -406,7 +406,7 @@ export class EnvironmentConfigLoader {
   }
 
   private async loadConfigFile(filePath: string, format: 'json' | 'yaml' | 'env'): Promise<any> {
-    const content: string = readFileSync(filePath, { encoding: 'utf8' });
+    const content = readFileSync(filePath, 'utf8');
 
     switch (format) {
       case 'json':


### PR DESCRIPTION
## Summary
- adjust environment configuration loader to use the UTF-8 overload of `readFileSync`, ensuring the returned value is always typed as a string when parsing configuration files

## Testing
- `npm run typecheck` *(fails: pre-existing type errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cdaa37412c8329a5c8f33860845e76