### PR TITLE
Fix lucide imports and restore settings utilities order

### DIFF
--- a/src/components/agent/AgentCard.tsx
+++ b/src/components/agent/AgentCard.tsx
@@ -1,22 +1,21 @@
 import React from 'react'
-import { 
 import { Agent } from '../../types'
 import { Avatar } from '../ui/Avatar'
 import { Badge } from '../ui/Badge'
 import { Button } from '../ui/Button'
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/Card'
 import { cn } from '../../utils/cn'
-
-  Activity, 
-  Clock, 
-  Cpu, 
-  MessageCircle, 
-  Settings, 
+import {
+  Activity,
+  Clock,
+  Cpu,
+  MessageCircle,
+  Settings,
   Zap,
   CheckCircle,
   AlertCircle,
   XCircle,
-  Pause
+  Pause,
 } from 'lucide-react'
 
 export interface AgentCardProps {

--- a/src/components/agent/ConfigurationPanel.tsx
+++ b/src/components/agent/ConfigurationPanel.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import {
 import { Agent } from '../../types'
 import { Badge } from '../ui/Badge'
 import { Button } from '../ui/Button'
@@ -8,6 +7,7 @@ import { cn } from '../../utils/cn'
 import { Form, useForm } from '../forms/Form'
 import { Input } from '../ui/Input'
 
+import {
   Settings,
   Save,
   RefreshCw,

--- a/src/components/agent/ConversationInterface.tsx
+++ b/src/components/agent/ConversationInterface.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import {
 import { Avatar } from '../ui/Avatar'
 import { Badge } from '../ui/Badge'
 import { Button } from '../ui/Button'
@@ -8,6 +7,7 @@ import { cn } from '../../utils/cn'
 import { Conversation, Message, Agent } from '../../types'
 import { Input } from '../ui/Input'
 
+import {
   Send,
   Paperclip,
   Smile,

--- a/src/components/agent/StatusDashboard.tsx
+++ b/src/components/agent/StatusDashboard.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import {
 import { Agent, Task, DashboardConfig, WidgetConfig } from '../../types'
 import { AgentCard } from './AgentCard'
 import { Badge } from '../ui/Badge'
@@ -7,6 +6,7 @@ import { Button } from '../ui/Button'
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/Card'
 import { cn } from '../../utils/cn'
 
+import {
   Activity,
   AlertCircle,
   CheckCircle,

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
-import {
 
+import {
   PaperAirplaneIcon,
   DocumentArrowUpIcon,
   MicrophoneIcon,

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import {
 import { Message } from '../../types';
 
+import {
   CheckIcon,
   ClockIcon,
   ExclamationCircleIcon,

--- a/src/components/chat/QuickActions.tsx
+++ b/src/components/chat/QuickActions.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import {
 import { QuickAction } from '../../types';
 
+import {
   MagnifyingGlassIcon,
   DocumentTextIcon,
   PencilSquareIcon,

--- a/src/components/common/Notification.tsx
+++ b/src/components/common/Notification.tsx
@@ -1,12 +1,12 @@
 import { createPortal } from 'react-dom'
 import React from 'react'
-import {
 import { Badge } from '../ui/Badge'
 import { Button } from '../ui/Button'
 import { Card, CardContent } from '../ui/Card'
 import { cn, animations } from '../../utils/cn'
 import { NotificationConfig, NotificationAction } from '../../types'
 
+import {
   CheckCircle,
   XCircle,
   AlertTriangle,

--- a/src/components/documents/DocumentCard.tsx
+++ b/src/components/documents/DocumentCard.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import {
 import { Document } from '../../types';
 
+import {
   DocumentTextIcon,
   EyeIcon,
   ArrowDownIcon,

--- a/src/components/documents/DocumentGrid.tsx
+++ b/src/components/documents/DocumentGrid.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useMemo } from 'react';
-import {
 import { Document } from '../../types';
 import { DocumentCard } from './DocumentCard';
 import { DocumentUpload } from './DocumentUpload';
 
+import {
   MagnifyingGlassIcon,
   AdjustmentsHorizontalIcon,
   FolderIcon,

--- a/src/components/documents/DocumentUpload.tsx
+++ b/src/components/documents/DocumentUpload.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef } from 'react';
 import type { FC, DragEvent, ChangeEvent } from 'react';
-import {
 
+import {
   CloudArrowUpIcon,
   DocumentTextIcon,
   XMarkIcon,

--- a/src/components/gpu/GPUAccelerationProvider.tsx
+++ b/src/components/gpu/GPUAccelerationProvider.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
-import {
 
+import {
   GPUAccelerationService,
   GPUServiceConfig,
   HardwareInfo,

--- a/src/components/knowledge/analytics/KnowledgeAnalyticsComponent.tsx
+++ b/src/components/knowledge/analytics/KnowledgeAnalyticsComponent.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import {
 
+import {
   AnalyticsQuery,
   AnalyticsResult,
   KnowledgeBaseStats

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {
 import { NavigationItem } from '../../types';
 
+import {
   ChatBubbleLeftRightIcon,
   DocumentTextIcon,
   MagnifyingGlassIcon,

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {
 import { SystemStatus } from '../../types';
 
+import {
   WifiIcon,
   ShieldCheckIcon,
   ClockIcon,

--- a/src/components/layout/UnifiedStatusBar.tsx
+++ b/src/components/layout/UnifiedStatusBar.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import {
 import { SystemStatus } from '../../types';
 import { useTheme } from '../../contexts/ThemeContext';
 
+import {
   WifiIcon,
   ShieldCheckIcon,
   ClockIcon,

--- a/src/components/legal/ContractAnalysisInterface.tsx
+++ b/src/components/legal/ContractAnalysisInterface.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import {
 
+import {
   FileText,
   Upload,
   Search,

--- a/src/components/local/LocalPerformanceDashboard.tsx
+++ b/src/components/local/LocalPerformanceDashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import {
 
+import {
   Activity,
   Cpu,
   MemoryStick,

--- a/src/components/local/LocalSettingsPanel.tsx
+++ b/src/components/local/LocalSettingsPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import {
 
+import {
   Settings,
   Shield,
   HardDrive,

--- a/src/components/local/OfflineErrorHandler.tsx
+++ b/src/components/local/OfflineErrorHandler.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import {
 
+import {
   AlertTriangle,
   WifiOff,
   RefreshCw,

--- a/src/components/search/GlobalSearch.tsx
+++ b/src/components/search/GlobalSearch.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useRef, useEffect } from 'react';
-import {
 import { SearchResult } from '../../types';
 import { SearchResults } from './SearchResults';
 
+import {
   MagnifyingGlassIcon,
   XMarkIcon,
   AdjustmentsHorizontalIcon,

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {
 import { SearchResult } from '../../types';
 
+import {
   DocumentTextIcon,
   ScaleIcon,
   BookOpenIcon,

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -1,11 +1,11 @@
 import React, { Component } from 'react'
-import {
 import { Badge } from './Badge'
 import { Button } from './Button'
 import { Card, CardContent, CardHeader, CardTitle } from './Card'
 import { cn } from '../../utils/cn'
 import { ErrorFallbackProps } from '../../types/modelTypes'
 
+import {
   AlertTriangle,
   RefreshCw,
   Home,

--- a/src/components/ui/MemoryUsageIndicator.tsx
+++ b/src/components/ui/MemoryUsageIndicator.tsx
@@ -1,9 +1,9 @@
 import { Activity, AlertTriangle, CheckCircle, XCircle, TrendingUp, TrendingDown, Minus } from 'lucide-react';
 import React from 'react';
-import {
 import { cn } from '@utils/cn';
 import { ComponentProps } from '../../types';
 
+import {
   MemoryInfo,
   MemoryStatus,
   MemoryTrend,

--- a/src/components/ui/ModelSelector.tsx
+++ b/src/components/ui/ModelSelector.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react'
-import {
 import { cn } from '../../utils/cn'
 
+import {
   Model,
   ModelStatus,
   ModelStatusType,

--- a/src/components/ui/NotificationSystem.tsx
+++ b/src/components/ui/NotificationSystem.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, createContext, useContext } from 'react'
-import { 
 import { cn } from '../../utils/cn'
 
+import {
   Notification, 
   NotificationAction, 
   NotificationPosition, 

--- a/src/components/ui/PerformanceDashboard.tsx
+++ b/src/components/ui/PerformanceDashboard.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react'
-import { 
 import { cn } from '../../utils/cn'
 
+import {
   PerformanceMetrics, 
   SystemMetrics, 
   ModelMetrics, 

--- a/src/components/ui/StreamingChatInterface.tsx
+++ b/src/components/ui/StreamingChatInterface.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react'
-import {
 import { cn } from '../../utils/cn'
 import type { ChatSession } from '../../types'
 
+import {
   StreamingResponse,
   Model,
   StreamingMetadata

--- a/src/examples/StreamingExample.tsx
+++ b/src/examples/StreamingExample.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import {
 
+import {
   StreamingChat,
   CompactStreamingChat,
   ConnectionStatus,

--- a/src/hooks/useStreaming.ts
+++ b/src/hooks/useStreaming.ts
@@ -1,6 +1,6 @@
-import {
 import { streamingService, StreamingService } from '../services/streamingService';
 
+import {
   StreamingMessage,
   StreamingChunk,
   ConnectionState,

--- a/src/services/knowledge/analytics/AnalyticsService.ts
+++ b/src/services/knowledge/analytics/AnalyticsService.ts
@@ -1,5 +1,5 @@
-import {
 
+import {
   AnalyticsQuery,
   AnalyticsResult,
   AnalyticsDataPoint,

--- a/src/services/knowledge/citations/CitationService.ts
+++ b/src/services/knowledge/citations/CitationService.ts
@@ -1,5 +1,5 @@
-import {
 
+import {
   Citation,
   Document,
   DocumentChunk,

--- a/src/services/knowledge/database/VectorDatabaseService.ts
+++ b/src/services/knowledge/database/VectorDatabaseService.ts
@@ -1,5 +1,5 @@
-import {
 
+import {
   Document,
   DocumentChunk,
   KnowledgeBaseConfig,

--- a/src/services/knowledge/graph/KnowledgeGraphService.ts
+++ b/src/services/knowledge/graph/KnowledgeGraphService.ts
@@ -1,5 +1,5 @@
-import {
 
+import {
   Document,
   KnowledgeNode,
   KnowledgeConnection,

--- a/src/services/knowledge/indexing/DocumentIndexer.ts
+++ b/src/services/knowledge/indexing/DocumentIndexer.ts
@@ -1,5 +1,5 @@
-import {
 
+import {
   Document,
   DocumentChunk,
   DocumentMetadata,

--- a/src/services/knowledge/rag/RAGService.ts
+++ b/src/services/knowledge/rag/RAGService.ts
@@ -1,5 +1,5 @@
-import {
 
+import {
   RAGContext,
   DocumentChunk,
   Document,

--- a/src/services/knowledge/search/SemanticSearchService.ts
+++ b/src/services/knowledge/search/SemanticSearchService.ts
@@ -1,5 +1,5 @@
-import {
 
+import {
   SearchQuery,
   SearchResult,
   SearchChunk,

--- a/src/services/knowledge/versioning/DocumentVersioningService.ts
+++ b/src/services/knowledge/versioning/DocumentVersioningService.ts
@@ -1,5 +1,5 @@
-import {
 
+import {
   Document,
   DocumentVersion,
   DocumentChange,

--- a/src/services/monitoring/localPerformanceMonitor.ts
+++ b/src/services/monitoring/localPerformanceMonitor.ts
@@ -1,5 +1,5 @@
-import {
 
+import {
   MonitoringConfig,
   MonitoringState,
   ModelPerformanceMetrics,

--- a/src/services/performanceOptimizer.ts
+++ b/src/services/performanceOptimizer.ts
@@ -1,5 +1,5 @@
-import {
 
+import {
   performanceMonitor,
   OptimizationSuggestion,
   PerformanceSummary

--- a/src/services/streamingService.ts
+++ b/src/services/streamingService.ts
@@ -1,6 +1,6 @@
-import {
 import { EventEmitter } from 'events';
 
+import {
   StreamingMessage,
   StreamingChunk,
   StreamingConfig,

--- a/src/utils/settings/settingsUtils.ts
+++ b/src/utils/settings/settingsUtils.ts
@@ -1,5 +1,6 @@
-export class SettingsUtils {
 import { LocalSettingsConfig, SettingsBackup, SettingsValidationError } from '../../types/settings';
+
+export class SettingsUtils {
 
   /**
    * Validates settings against a schema


### PR DESCRIPTION
## Summary
- normalize `lucide-react` imports across the UI components and related services so that each statement includes its specifiers
- move the settings utilities type imports back above the `SettingsUtils` class declaration to keep the module valid

## Testing
- npm run typecheck *(fails: existing TypeScript errors in unrelated UI and service modules)*
- cargo check *(fails: unable to reach crates.io due to 403 CONNECT tunnel error)*

------
https://chatgpt.com/codex/tasks/task_e_68cf077049bc8329bd185c95558135fa