### PR TITLE
Fix postinstall script for cross-platform compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "install:bear-ai:verbose": "node scripts/install-bear-ai.js --verbose",
     "install:bear-ai:dev": "node scripts/install-bear-ai.js --verbose --dev",
     "setup": "node scripts/install-bear-ai.js",
-    "postinstall": "node -e \"console.log('\n BEAR AI installed! Run: npm start\n')\"",
+    "postinstall": "node scripts/postinstall-message.js",
     "fix-python": "node scripts/fix-python-deps.js",
     "cleanup-install": "node scripts/cleanup-installers.js",
     "windows-launcher": "node scripts/start-bear-ai.js",

--- a/scripts/postinstall-message.js
+++ b/scripts/postinstall-message.js
@@ -1,0 +1,1 @@
+console.log('\n BEAR AI installed! Run: npm start\n');


### PR DESCRIPTION
## Summary
- replace the inline Node one-liner postinstall script with a dedicated file to avoid Windows quoting issues
- add a reusable `scripts/postinstall-message.js` that prints the installation message without relying on embedded newlines

## Testing
- node scripts/postinstall-message.js

------
https://chatgpt.com/codex/tasks/task_e_68cf0f10a918832985d20700b5c0bd7e