### PR TITLE
Align Tauri dependencies with v1 release

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,12 +9,12 @@ edition = "2021"
 rust-version = "1.70"
 
 [build-dependencies]
-tauri-build = { version = "1.6", features = [] }
+tauri-build = { version = "1", features = [] }
 
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.6.8", features = ["system-tray", "api-all", "updater", "window-all", "fs-all", "path-all", "protocol-all", "process-all", "shell-all", "http-all", "notification-all", "global-shortcut-all", "os-all", "dialog-all", "cli", "macos-private-api"] }
+tauri = { version = "1", features = ["system-tray", "api-all", "updater", "window-all", "fs-all", "path-all", "protocol-all", "process-all", "shell-all", "http-all", "notification-all", "global-shortcut-all", "os-all", "dialog-all", "cli", "macos-private-api"] }
 tokio = { version = "1.0", features = ["full"] }
 anyhow = "1.0"
 log = "0.4"


### PR DESCRIPTION
## Summary
- relax the tauri-build dependency constraint so the project can resolve a stable Tauri v1 build script
- align the main tauri crate requirement with the v1 release line to avoid selecting unavailable minor versions

## Testing
- cargo check --manifest-path src-tauri/Cargo.toml *(fails: crates.io index fetch blocked by 403 CONNECT tunnel response)*

------
https://chatgpt.com/codex/tasks/task_e_68cfbbbbb9a083298c22239f8271edff