### PR TITLE
Adjust CI workflow to avoid npx downloads

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,35 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: |
+        npm config set registry https://registry.npmjs.org/
+        npm ci --prefer-offline --no-audit
+
+    - name: Run TypeScript check
+      run: npm run typecheck
+
+    - name: Run tests
+      run: npm test -- --watchAll=false
+
+    - name: Build application
+      run: npm run build

--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     "which": "^5.0.0"
   },
   "scripts": {
-    "start": "npx react-scripts start",
-    "build": "npx react-scripts build",
+    "start": "react-scripts start",
+    "build": "react-scripts build",
     "build:unified": "react-scripts build",
     "build:with-typecheck": "npm run typecheck:build && react-scripts build",
     "build:alpha": "set SKIP_PREFLIGHT_CHECK=true && set GENERATE_SOURCEMAP=false && react-scripts build",
@@ -95,8 +95,8 @@
     "test:coverage": "jest --config tests/jest.config.js --coverage",
     "test:api:coverage": "jest --config jest.api.config.js --coverage",
     "eject": "react-scripts eject",
-    "lint": "npx eslint@8.57.0 src --ext .ts,.tsx",
-    "lint:fix": "npx eslint@8.57.0 src --ext .ts,.tsx --fix",
+    "lint": "node node_modules/react-scripts/node_modules/eslint/bin/eslint.js src --ext .ts,.tsx",
+    "lint:fix": "node node_modules/react-scripts/node_modules/eslint/bin/eslint.js src --ext .ts,.tsx --fix",
     "lint:alpha": "echo 'Skipping ESLint for alpha build'",
     "typecheck": "tsc --noEmit --skipLibCheck",
     "typecheck:strict": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- update npm scripts to rely on locally installed react-scripts and eslint binaries
- add a dedicated Build and Test GitHub Actions workflow that installs dependencies and runs typecheck, tests, and build using cached npm modules

## Testing
- not run (environment lacks npm registry access)

------
https://chatgpt.com/codex/tasks/task_e_68d1260779f08329ab2f93e4fdf80785