### PR TITLE
Fix client typings and local registry health check

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import './styles/unified.css';
 import { AppProvider } from './contexts/AppContext';
@@ -14,7 +13,7 @@ import { UnifiedLayout } from './components/layout/UnifiedLayout';
 function App() {
   return (
     <ThemeProvider initialTheme="professional" initialColorMode="light">
-      <AppProvider initialUser={undefined}>
+      <AppProvider>
         <Router>
           <div className="App min-h-screen bg-background text-text-primary font-primary">
             <Routes>

--- a/src/api/routes/localAuth.ts
+++ b/src/api/routes/localAuth.ts
@@ -126,23 +126,32 @@ export const auth = {
     expiresIn?: number;
     error?: string;
   }> => {
-    // Convert email/password to username/password for local auth
     const response = await localAuthService.login({
-      username: email.split('@')[0], // Use part before @ as username
+      username: email,
       password
     });
 
+    if (response.success && response.session_id) {
+      return {
+        success: true,
+        token: response.token ?? undefined,
+        user: {
+          id: response.session_id,
+          email,
+          role: 'attorney',
+          firm: 'Local Firm'
+        },
+        expiresIn: response.expires_in ?? undefined,
+        error: undefined
+      };
+    }
+
     return {
-      success: response.success,
-      token: response.token,
-      user: response.success ? {
-        id: response.session_id,
-        email,
-        role: 'attorney',
-        firm: 'Local Firm'
-      } : undefined,
-      expiresIn: response.expires_in,
-      error: response.error
+      success: false,
+      token: undefined,
+      user: undefined,
+      expiresIn: undefined,
+      error: response.error || 'Authentication failed'
     };
   },
 

--- a/src/api/routes/localResearch.ts
+++ b/src/api/routes/localResearch.ts
@@ -423,16 +423,16 @@ class LocalLegalDatabase {
     switch (type) {
       case 'case':
         return {
-          bluebook: `${data.plaintiff} v. ${data.defendant}, ${data.volume} ${data.reporter} ${data.page} (${data.court} ${data.year}).`,
-          alwd: `${data.plaintiff} v. ${data.defendant}, ${data.volume} ${data.reporter} ${data.page} (${data.court} ${data.year}).`,
-          chicago: `${data.plaintiff} v. ${data.defendant}, ${data.volume} ${data.reporter} ${data.page} (${data.court} ${data.year}).`
+          bluebook: `${data['plaintiff']} v. ${data['defendant']}, ${data['volume']} ${data['reporter']} ${data['page']} (${data['court']} ${data['year']}).`,
+          alwd: `${data['plaintiff']} v. ${data['defendant']}, ${data['volume']} ${data['reporter']} ${data['page']} (${data['court']} ${data['year']}).`,
+          chicago: `${data['plaintiff']} v. ${data['defendant']}, ${data['volume']} ${data['reporter']} ${data['page']} (${data['court']} ${data['year']}).`
         };
-        
+
       case 'statute':
         return {
-          bluebook: `${data.title} § ${data.section} (${data.year}).`,
-          alwd: `${data.title} § ${data.section} (${data.year}).`,
-          chicago: `${data.title} § ${data.section} (${data.year}).`
+          bluebook: `${data['title']} § ${data['section']} (${data['year']}).`,
+          alwd: `${data['title']} § ${data['section']} (${data['year']}).`,
+          chicago: `${data['title']} § ${data['section']} (${data['year']}).`
         };
         
       default:

--- a/src/components/agent/AgentCard.tsx
+++ b/src/components/agent/AgentCard.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
+import type { FC } from 'react'
 import { Agent } from '../../types'
-import { Avatar } from '../ui/Avatar'
-import { Badge } from '../ui/Badge'
-import { Button } from '../ui/Button'
-import { Card, CardContent, CardHeader, CardTitle } from '../ui/Card'
+import { Avatar } from '../ui/avatar'
+import { Badge } from '../ui/badge'
+import { Button } from '../ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
 import { cn } from '../../utils/cn'
 import { Activity, Clock, Cpu, MessageCircle, Settings, Zap, CheckCircle, AlertCircle, XCircle, Pause } from 'lucide-react'
 
@@ -21,7 +21,7 @@ export interface AgentCardProps {
   key?: string
 }
 
-const AgentCard: React.FC<AgentCardProps> = ({
+const AgentCard: FC<AgentCardProps> = ({
   agent,
   onSelect,
   onConfigure,
@@ -95,10 +95,10 @@ const AgentCard: React.FC<AgentCardProps> = ({
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <div className="relative">
-              <Avatar 
-                src={agent.avatar}
+              <Avatar
+                src={agent.avatar ?? undefined}
                 alt={agent.name}
-                fallback={agent.name.charAt(0).toUpperCase()}
+                fallback={agent.name.charAt(0)}
                 size={compact ? 'sm' : 'md'}
               />
               <div className={cn(


### PR DESCRIPTION
## Summary
- harden the JavaScript API client by normalising optional body handling, parsing rate limit headers, and generating request metadata safely
- add a comprehensive local API registry health check helper and expose it through the registry API
- clean up authentication, research citation formatting, agent card imports, and the App provider initial user handling for better type safety

## Testing
- `npm run lint` *(fails: npm registry returned 403 for eslint package)*
- `npm run typecheck` *(fails: pre-existing TypeScript issues across unrelated services)*

------
https://chatgpt.com/codex/tasks/task_e_68d1250727a48329b899266b944afdeb