### PR TITLE
Fix npm ci dependency mismatches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "typescript": "^4.9.5",
         "uuid": "^10.0.0",
         "web-vitals": "^4.2.3",
-        "ws": "^8.18.0"
+        "ws": "^8.18.0",
+        "openapi-types": "^12.1.3"
       },
       "devDependencies": {
         "@playwright/test": "^1.47.2",
@@ -70,7 +71,9 @@
         "tailwindcss": "^3.4.12",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
-        "which": "^5.0.0"
+        "which": "^5.0.0",
+        "@testing-library/dom": "^10.4.1",
+        "postcss-selector-parser": "^6.1.2"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -25658,6 +25661,104 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "license": "MIT"
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "^5.3.0",
+        "dequal": "^2.0.3",
+        "dom-accessibility-api": "^0.5.16",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.4.6"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "*"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@testing-library/dom/node_modules/dequal": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom/node_modules/lz-string": {
+      "version": "1.5.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-router-dom": "^6.26.2",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
+    "openapi-types": "^12.1.3",
     "tailwind-merge": "^2.5.2",
     "typescript": "^4.9.5",
     "uuid": "^10.0.0",
@@ -33,6 +34,7 @@
     "ajv": "^6.12.6",
     "@playwright/test": "^1.47.2",
     "@testing-library/jest-dom": "^6.5.0",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.5.2",
     "@types/compression": "^1.7.5",
@@ -64,6 +66,7 @@
     "tailwindcss": "^3.4.12",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
+    "postcss-selector-parser": "^6.1.2",
     "which": "^5.0.0"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- add the missing `openapi-types`, `@testing-library/dom`, and `postcss-selector-parser` entries to the project manifest so peer requirements are satisfied
- extend the lockfile with the corresponding modules and transitive dependencies required by `@testing-library/dom` and `postcss-selector-parser`

## Testing
- npm ci --dry-run *(fails: registry access returns 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d128c0289c83298a69c1e2bbcbbc6c