### PR TITLE
Fix Jest rootDir configuration to resolve setup file

### DIFF
--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -1,7 +1,11 @@
 // Jest Configuration for BEAR AI Testing Suite
 // Comprehensive testing setup with coverage reporting and multiple test environments
 
+const path = require('path');
+
 module.exports = {
+  // Root directory for the project
+  rootDir: path.resolve(__dirname, '..'),
   // Test environment
   testEnvironment: 'jsdom',
 


### PR DESCRIPTION
## Summary
- set the Jest configuration's rootDir to the project root so setup files resolve correctly when running tests

## Testing
- npm test -- --watchAll=false *(fails: jest binary unavailable because npm install is blocked by registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d133d4b3508329a007b81763adadc7