### PR TITLE
Handle optional Jest reporters

### DIFF
--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -3,6 +3,40 @@
 
 const path = require('path');
 
+const reporters = ['default'];
+
+const isCI = Boolean(process.env.CI);
+
+const addReporterIfAvailable = (name, options) => {
+  try {
+    require.resolve(name);
+    reporters.push(options ? [name, options] : name);
+  } catch (error) {
+    if (isCI) {
+      // eslint-disable-next-line no-console
+      console.warn(`Optional Jest reporter "${name}" is not installed. Skipping.`);
+    }
+  }
+};
+
+addReporterIfAvailable('jest-junit', {
+  outputDirectory: 'test-results',
+  outputName: 'junit.xml',
+  ancestorSeparator: ' › ',
+  uniqueOutputName: 'false',
+  suiteNameTemplate: '{displayName} {filepath}',
+  classNameTemplate: '{classname}',
+  titleTemplate: '{title}'
+});
+
+addReporterIfAvailable('jest-html-reporters', {
+  publicDir: 'test-results',
+  filename: 'test-report.html',
+  expand: true,
+  hideIcon: false,
+  pageTitle: 'BEAR AI Test Report'
+});
+
 module.exports = {
   // Root directory for the project
   rootDir: path.resolve(__dirname, '..'),
@@ -190,31 +224,7 @@ module.exports = {
   notifyMode: 'failure-change',
 
   // Reporter configuration
-  reporters: [
-    'default',
-    [
-      'jest-junit',
-      {
-        outputDirectory: 'test-results',
-        outputName: 'junit.xml',
-        ancestorSeparator: ' › ',
-        uniqueOutputName: 'false',
-        suiteNameTemplate: '{displayName} {filepath}',
-        classNameTemplate: '{classname}',
-        titleTemplate: '{title}'
-      }
-    ],
-    [
-      'jest-html-reporters',
-      {
-        publicDir: 'test-results',
-        filename: 'test-report.html',
-        expand: true,
-        hideIcon: false,
-        pageTitle: 'BEAR AI Test Report'
-      }
-    ]
-  ],
+  reporters,
 
   // Custom matchers and utilities
   snapshotSerializers: [


### PR DESCRIPTION
## Summary
- load optional jest reporters only when the packages are available so the test suite can run without extra dev dependencies
- log a warning in CI environments when an optional reporter package is missing

## Testing
- npm test -- --watchAll=false *(fails: local environment is missing Jest binaries prior to install)*


------
https://chatgpt.com/codex/tasks/task_e_68d135fecfc483299938d46aaa87e4f6