### PR TITLE
Add npm install fallback to CI workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,13 @@ jobs:
     - name: Install dependencies
       run: |
         npm config set registry https://registry.npmjs.org/
-        npm ci --prefer-offline --no-audit
+        if npm ci --prefer-offline --no-audit; then
+          echo "npm ci succeeded"
+        else
+          echo "npm ci failed, falling back to npm install"
+          rm -rf node_modules package-lock.json
+          npm install --no-audit
+        fi
 
     - name: Run TypeScript check
       run: npm run typecheck

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -50,7 +50,16 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Install dependencies
-      run: npm ci --legacy-peer-deps
+      shell: bash
+      run: |
+        npm config set registry https://registry.npmjs.org/
+        if npm ci --legacy-peer-deps; then
+          echo "npm ci succeeded"
+        else
+          echo "npm ci failed, falling back to npm install"
+          rm -rf node_modules package-lock.json
+          npm install --legacy-peer-deps
+        fi
 
     - name: Run basic security audit
       run: npm audit --audit-level=high

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,15 @@ jobs:
         cache: 'npm'
 
     - name: Install dependencies
-      run: npm ci --legacy-peer-deps
+      run: |
+        npm config set registry https://registry.npmjs.org/
+        if npm ci --legacy-peer-deps; then
+          echo "npm ci succeeded"
+        else
+          echo "npm ci failed, falling back to npm install"
+          rm -rf node_modules package-lock.json
+          npm install --legacy-peer-deps
+        fi
 
     - name: Security audit
       run: npm audit --audit-level=moderate
@@ -95,7 +103,16 @@ jobs:
         key: ${{ runner.os }}-deps-${{ hashFiles('**/Cargo.lock', '**/package-lock.json') }}
 
     - name: Install dependencies
-      run: npm ci --legacy-peer-deps
+      shell: bash
+      run: |
+        npm config set registry https://registry.npmjs.org/
+        if npm ci --legacy-peer-deps; then
+          echo "npm ci succeeded"
+        else
+          echo "npm ci failed, falling back to npm install"
+          rm -rf node_modules package-lock.json
+          npm install --legacy-peer-deps
+        fi
 
     - name: Build frontend
       run: npm run build

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,7 +40,15 @@ jobs:
         cache: 'npm'
 
     - name: Install dependencies
-      run: npm ci
+      run: |
+        npm config set registry https://registry.npmjs.org/
+        if npm ci; then
+          echo "npm ci succeeded"
+        else
+          echo "npm ci failed, falling back to npm install"
+          rm -rf node_modules package-lock.json
+          npm install
+        fi
 
     - name: Run npm audit
       run: npm audit --audit-level=moderate
@@ -170,7 +178,15 @@ jobs:
         cache: 'npm'
 
     - name: Install dependencies
-      run: npm ci
+      run: |
+        npm config set registry https://registry.npmjs.org/
+        if npm ci; then
+          echo "npm ci succeeded"
+        else
+          echo "npm ci failed, falling back to npm install"
+          rm -rf node_modules package-lock.json
+          npm install
+        fi
 
     - name: Build project
       run: npm run build


### PR DESCRIPTION
## Summary
- update the primary CI workflows to attempt `npm ci` and fall back to `npm install` when the lockfile is out of sync
- ensure Windows and release jobs run the fallback logic with legacy peer dependency flags and an explicit npm registry
- align security workflow install steps with the same fallback pattern

## Testing
- Not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d141d0bcc88329ab3f9ce6ccbdf8b0