### PR TITLE
Fix user-event configuration error in test setup

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,7 +1,6 @@
 import '@testing-library/jest-dom';
 import { expect, vi } from 'vitest';
 import { configure } from '@testing-library/react';
-import { configure as configureUserEvent } from '@testing-library/user-event';
 import { toHaveNoViolations } from 'jest-axe';
 
 declare global {
@@ -49,10 +48,6 @@ configure({
   computedStyleSupportsPseudoElements: true,
 });
 
-configureUserEvent({
-  advanceTimers: vi.advanceTimersByTime,
-  delay: null,
-});
 
 const globalAny = globalThis as any;
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,8 +31,10 @@ export default defineConfig({
       },
     },
     // Mock Tauri APIs for testing
-    deps: {
-      inline: ['@tauri-apps/api'],
+    server: {
+      deps: {
+        inline: ['@tauri-apps/api'],
+      },
     },
     alias: {
       '@': resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- remove the deprecated `configure` import from `@testing-library/user-event` in the shared test setup to resolve the Vitest TypeError
- switch the Vitest dependency inlining setting to the new `server.deps.inline` option so the config no longer relies on a deprecated field

## Testing
- npm run test:frontend *(fails: Vitest binary unavailable because npm install cannot reach https://registry.npmjs.org/@vitejs%2fplugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68d1472ae81c8329aac9bf83335c5f41