### PR TITLE
Fix PIIDetection hook initialization and Dutch RSIN validation

### DIFF
--- a/src/services/pii/DutchComplianceValidator.ts
+++ b/src/services/pii/DutchComplianceValidator.ts
@@ -57,35 +57,13 @@ export class DutchComplianceValidator {
    * Validate Dutch RSIN (Rechtspersonen Samenwerkingsverbanden Informatie Nummer)
    */
   public validateRSIN(rsin: string | null | undefined): boolean {
-    if (!rsin || typeof rsin !== 'string') {
+    const cleanRSIN = this.sanitizeDutchNumber(rsin);
+
+    if (!cleanRSIN || cleanRSIN === '000000000' || this.hasInvalidRepetition(cleanRSIN)) {
       return false;
     }
 
-    const cleanRSIN = rsin.replace(/[\s\-.]/g, '');
-
-    if (!/^\d{9}$/.test(cleanRSIN) || this.hasInvalidRepetition(cleanRSIN)) {
-      return false;
-    }
-
-    return this.validateRSINChecksum(cleanRSIN);
-  }
-
-  private validateRSINChecksum(rsin: string): boolean {
-    const digits = rsin.split('').map(Number);
-    let sum = 0;
-
-    for (let i = 0; i < 8; i++) {
-      sum += digits[i] * (9 - i);
-    }
-
-    const remainder = sum % 11;
-
-    if (remainder === 1) {
-      return false;
-    }
-
-    const checkDigit = remainder === 0 ? 0 : 11 - remainder;
-    return checkDigit === digits[8];
+    return this.apply11Test(cleanRSIN);
   }
 
   /**


### PR DESCRIPTION
## Summary
- lazily instantiate the PII detector inside `usePIIDetection`, add safer real-time scanning with optional callbacks, and improve fallback handling for errors and audit helpers
- delegate masking/audit helpers to the detector when available to keep behavior consistent with tests
- align Dutch RSIN validation with the BSN 11-test so clearly invalid numbers are rejected

## Testing
- npm run test -- src/tests/pii *(fails: `vitest` binary not available in the container and `npm install` is blocked by 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d1553315d88329b4d04a26023e1faf